### PR TITLE
Breach and Clear improvements

### DIFF
--- a/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/Briefing.layer
+++ b/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/Briefing.layer
@@ -52,9 +52,11 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   coords 1479.754 14.239 2061.747
   m_sTitle "Sustainment"
   m_sTextData "G4 has told us that we have no additional resupply, forces are to attack with what they have on themselves."\
+  ""\
+  "We have 1x supply MATV with 30 WP smoke grenades and 8 Assault ladders"\
   "(Unless the GMs magic stuff)"
   m_aVisibleForFactions {
-   "UK"
+   "RHS_USAF"
   }
   m_iOrder 3
  }
@@ -76,7 +78,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "3 Squad: 1'3"\
   "Weapons Squad: 1'4"
   m_aVisibleForFactions {
-   "RHS_USRF"
+   "RHS_USAF"
   }
   m_iOrder 4
  }
@@ -131,11 +133,11 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTitle "Notes"
   m_sTextData "Basic attack and defend of an residential block."\
   ""\
-  "3-4:1 ratio"\
+  "4:1 ratio"\
   ""\
   "No time limit"\
   ""\
-  "Setup timer is 7 minutes"\
+  "Setup timer is 1 minute"\
   ""\
   "Casualty conditions apply at 90% for Blufor 100% for Opfor"\
   ""\

--- a/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/Fixtures.layer
+++ b/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/Fixtures.layer
@@ -290,6 +290,7 @@ Tree : "{61D918F6575A3231}PrefabLibrary/Vegetation/Trees/t_alnus_glutinosa_2s.et
  angleY 198.276
  angleZ 0.189
  scale 0.937
+ Enabled 0
  MaxHealth 5000
 }
 GenericEntity : "{67D13407B9B9D626}Prefabs/Props/Industrial/Pallets/MarsBox_01_wood.et" {
@@ -579,7 +580,7 @@ $grp StaticModelEntity : "{93E06E731212BD96}Prefabs/Structures/Walls/BarbedWire/
   angleY -110.782
  }
  {
-  coords 1507.495 -0 2236.872
+  coords 1507.495 0 2236.872
   angleY -110.782
  }
  {
@@ -587,7 +588,7 @@ $grp StaticModelEntity : "{93E06E731212BD96}Prefabs/Structures/Walls/BarbedWire/
   angleY -115.767
  }
  {
-  coords 1510.266 -0 2237.924
+  coords 1510.266 0 2237.924
   angleY -110.782
  }
  {

--- a/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/Fixtures.layer
+++ b/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/Fixtures.layer
@@ -11,6 +11,9 @@ $grp SCR_DestructibleEntity : "{06ABA7878E8CC278}Prefabs/Props/Decorations/Flowe
   angleY 60.914
  }
 }
+GenericEntity : "{07D5C7C755C719BE}Prefabs/Props/Garbage/Generic/Junk_01/Junk_01_pile_medium.et" {
+ coords 1509.942 20.719 2235.404
+}
 $grp GenericEntity : "{10BC0DF4C149DECC}Prefabs/Compositions/Misc/SubCompositions/Decorations/PalletPile_Stacked_01.et" {
  {
   coords 1472.07 20.656 2261.942
@@ -91,23 +94,44 @@ $grp Vehicle : "{128253A267BE9424}Prefabs/Vehicles/Wheeled/S105/S105_randomized.
   coords 1491.064 20.779 2227.061
   angleY 153.13
  }
- S105_randomized6 {
-  components {
-   SCR_FuelManagerComponent "{5622A70CD78A9E2C}" {
-    FuelNodes {
-     SCR_FuelNode "{5622A70CD4036C5A}" {
-      MaxFuel 0
-      m_fInitialFuelTankState 0
-     }
-    }
-   }
-  }
-  coords 1477.417 20.656 2264.3
-  angleY 62.072
+}
+$grp Tree : "{16D3707EA3F8DD41}PrefabLibrary/Vegetation/Trees/t_alnus_glutinosa_3s.et" {
+ {
+  coords 1482.999 -0.086 2238.022
+  angleX -2.899
+  angleY 210.329
+  angleZ 1.686
+  scale 1.009
+  Enabled 0
+  MaxHealth 10000000
+  DamageThreshold 100000
+ }
+ {
+  coords 1486.401 -0.002 2236.757
+  angleX 2.258
+  angleY 108.221
+  angleZ 2.479
+  scale 1.009
+  Enabled 0
+  MaxHealth 10000000
+  DamageThreshold 100000
+ }
+}
+$grp GenericEntity : "{17268A1479D32278}PrefabLibrary/Infrastructure/Lamps/LampStreet_E_03_addon/LampStreet_E_03_addon.et" {
+ {
+  coords 1478.466 5.54 2259.848
+  angleY -28.948
+ }
+ {
+  coords 1456.84 5.54 2274.205
+  angleY 147.862
  }
 }
 GenericEntity : "{20759E1CA7F808BE}Prefabs/Props/Garbage/Military/Food/GarbageFoodMilitaryUS_01.et" {
  coords 1478.819 20.656 2244.697
+}
+SCR_DestructibleBuildingEntity : "{2863568293E03506}PrefabsEditable/Auto/Structures/Ruins/HouseRuins/E_HouseRuin_01_WoodPile.et" {
+ coords 1479.722 0.099 2242.078
 }
 $grp GenericEntity : "{2887E99075B9C928}Prefabs/Props/Garbage/Generic/Litter_01_long.et" {
  {
@@ -132,6 +156,20 @@ $grp GenericEntity : "{2887E99075B9C928}Prefabs/Props/Garbage/Generic/Litter_01_
  {
   coords 1438.201 20.656 2315.797
   angleY 44.006
+ }
+}
+$grp GenericEntity : "{29063844DEEAC10B}Prefabs/Props/Garbage/Generic/Junk_01/Junk_01_pile_large.et" {
+ {
+  coords 1509.434 20.562 2237.708
+  angleY -16.659
+ }
+ {
+  coords 1514.674 20.563 2237.322
+  angleY -16.659
+ }
+ {
+  coords 1473.95 20.741 2196.114
+  angleY -16.659
  }
 }
 GenericEntity : "{2B26287DC5B7F9D0}Prefabs/Props/Industrial/ToolBox_01/ToolBox_01_red.et" {
@@ -169,6 +207,25 @@ $grp GenericEntity : "{3BAF6AA8C20D924E}Prefabs/Compositions/Misc/SubComposition
   coords 1467.613 20.56 2192.992
   angleY -32.787
  }
+ {
+  coords 1520.231 20.695 2242.294
+  angleY -32.787
+ }
+ {
+  coords 1508.595 20.562 2237.199
+  angleY -32.787
+ }
+ {
+  coords 1514.443 20.562 2239.563
+  angleY -37.771
+ }
+}
+Tree : "{407A7B6D0444D05B}PrefabLibrary/Vegetation/Plants/b_urtica_dioica_0s.et" {
+ coords 1477.858 0 2259.375
+ angleX 2.65
+ angleY 281.852
+ angleZ -1.408
+ scale 1.106
 }
 $grp GenericEntity : "{479481B171F52B35}PrefabsEditable/Auto/Structures/Infrastructure/Lamps/LampStreet_E_01/E_LampStreet_E_01_6m.et" {
  {
@@ -224,6 +281,17 @@ $grp GenericEntity : "{5E99DD1E8377D27F}Prefabs/Props/Garbage/Bins/TrashBin_02.e
   coords 1478.349 20.656 2244.212
  }
 }
+SCR_EditorRestrictionZoneEntity : "{6144B0BE2EAC6897}PrefabsEditable/RestrictionZone/E_EditorRestrictionZoneMedium.et" {
+ coords 1593.733 19.178 2124.212
+}
+Tree : "{61D918F6575A3231}PrefabLibrary/Vegetation/Trees/t_alnus_glutinosa_2s.et" {
+ coords 1458.556 0.03 2288.481
+ angleX -0.887
+ angleY 198.276
+ angleZ 0.189
+ scale 0.937
+ MaxHealth 5000
+}
 GenericEntity : "{67D13407B9B9D626}Prefabs/Props/Industrial/Pallets/MarsBox_01_wood.et" {
  coords 1502.717 20.656 2218.643
  angleY 63.19
@@ -275,8 +343,14 @@ $grp GenericEntity : "{72E42BEAFED9B5A7}Prefabs/Props/Garbage/Bins/GarbageContai
   angleY 63.254
  }
 }
-GenericEntity : "{74D1DB7828061BD7}Prefabs/Props/Garbage/Generic/Junk_01/Junk_01_pile_small.et" {
- coords 1473.39 20.656 2251.994
+$grp GenericEntity : "{74D1DB7828061BD7}Prefabs/Props/Garbage/Generic/Junk_01/Junk_01_pile_small.et" {
+ {
+  coords 1473.39 20.656 2251.994
+ }
+ {
+  coords 1517.936 20.562 2239.175
+  angleY -15.518
+ }
 }
 SCR_DestructibleBuildingEntity : "{8597237EA3C59701}Prefabs/Structures/Houses/Shed/Shed_03/Shed_03.et" {
  coords 1472.221 0 2260.974
@@ -307,6 +381,44 @@ $grp GenericEntity : "{8F130A320B6CEB6F}PrefabsEditable/Auto/Structures/Infrastr
  {
   coords 1498.134 0.047 2189.234
   angleY -28.157
+ }
+}
+TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramework.et" {
+ coords 1581.825 20.219 2163.665
+ m_missionEvents {
+  TILW_MissionEvent "{6508D983AB223731}" {
+   m_instructions {
+    TILW_EndGameInstruction "{65069348739519D9}" {
+     m_executionDelay 10
+     m_factionKey "RHS_USAF"
+    }
+   }
+   m_condition TILW_LiteralTerm "{650693486309A08D}" {
+    m_flagName "ruloss"
+   }
+  }
+  TILW_MissionEvent "{6508D983AB010064}" {
+   m_instructions {
+    TILW_EndGameInstruction "{65069348969E23B6}" {
+     m_executionDelay 10
+     m_factionKey "RHS_AFRF"
+    }
+   }
+   m_condition TILW_LiteralTerm "{65069348934167CA}" {
+    m_flagName "usloss"
+   }
+  }
+ }
+ m_casualtyFlags {
+  TILW_FactionPlayersKilledFlag "{6508D983B68DAC36}" {
+   m_flagName "ruloss"
+   m_factionKey "RHS_AFRF"
+  }
+  TILW_FactionAIKilledFlag "{6508D983B978509E}" {
+   m_flagName "usloss"
+   m_factionKey "RHS_USAF"
+   m_casualtyRatio 0.9
+  }
  }
 }
 GenericEntity : "{90A74133C1DC6226}Prefabs/Props/Industrial/Repair/EngineCrane_01.et" {
@@ -430,6 +542,58 @@ $grp StaticModelEntity : "{93E06E731212BD96}Prefabs/Structures/Walls/BarbedWire/
   coords 1481.903 0.231 2198.696
   angleY -110.782
  }
+ {
+  coords 1446.785 0.346 2267.014
+  angleY -25.291
+ }
+ {
+  coords 1510.815 -0.133 2236.53
+  angleY -110.782
+ }
+ {
+  coords 1513.925 -0.133 2237.747
+  angleY -115.767
+ }
+ {
+  coords 1516.595 -0.133 2239.035
+  angleY -115.767
+ }
+ {
+  coords 1521.902 0.119 2243.019
+  angleY -110.782
+ }
+ {
+  coords 1513.376 0 2239.141
+  angleY -115.767
+ }
+ {
+  coords 1519.681 0 2240.573
+  angleY -110.782
+ }
+ {
+  coords 1519.131 0.133 2241.967
+  angleY -110.782
+ }
+ {
+  coords 1508.044 -0.133 2235.478
+  angleY -110.782
+ }
+ {
+  coords 1507.495 -0 2236.872
+  angleY -110.782
+ }
+ {
+  coords 1516.046 0 2240.429
+  angleY -115.767
+ }
+ {
+  coords 1510.266 -0 2237.924
+  angleY -110.782
+ }
+ {
+  coords 1522.451 -0.002 2241.625
+  angleY -110.782
+ }
 }
 GenericEntity : "{95D947E744336F78}Prefabs/Props/Industrial/Workbench_01.et" {
  coords 1485.035 20.79 2221.582
@@ -454,18 +618,48 @@ $grp GenericEntity : "{A285421E5231FF5A}Prefabs/Props/Garbage/Generic/GarbageGen
   coords 1440.912 20.656 2321.133
  }
 }
-GenericEntity : "{A446CB3C732A360D}Prefabs/Props/Garbage/Generic/Junk_01/Junk_01_pile_long.et" {
- coords 1494.549 20.585 2209.981
- angleZ 0.623
+$grp GenericEntity : "{A446CB3C732A360D}Prefabs/Props/Garbage/Generic/Junk_01/Junk_01_pile_long.et" {
+ {
+  coords 1494.549 20.585 2209.981
+  angleZ 0.623
+ }
+ {
+  coords 1521.484 20.524 2240.699
+  angleX 0.23
+  angleY -21.639
+  angleZ 0.579
+ }
+ {
+  coords 1514.761 20.416 2240.313
+  angleX 0.23
+  angleY -21.639
+  angleZ 0.579
+ }
+ {
+  coords 1521.358 20.571 2244.45
+  angleX -0.212
+  angleY 19.876
+  angleZ 0.586
+ }
 }
 $grp GenericEntity : "{A8D8015D0E2B600A}Prefabs/Props/Garbage/Generic/Junk_01/Junk_01_single_mattress.et" {
  {
-  coords 1482.862 20.656 2250.014
+  coords 1482.744 20.656 2249.968
   angleY -14.635
  }
  {
   coords 1449.878 21.645 2298.385
   angleZ -59.449
+ }
+}
+$grp GenericEntity : "{AC5172F00941C060}PrefabsEditable/Auto/Props/Military/Sandbags/E_Sandbag_01_wall_burlap.et" {
+ {
+  coords 1478.727 27.448 2217.771
+  angleY -25.035
+ }
+ {
+  coords 1480.877 27.448 2218.775
+  angleY -25.035
  }
 }
 GenericEntity : "{B2DCC836439482A9}Prefabs/Props/Garbage/Generic/GarbageGeneric_01_sparse.et" {
@@ -571,6 +765,91 @@ $grp GenericEntity : "{C58BDB4D22E0A5A7}Prefabs/Props/Garbage/Generic/Litter_01_
   angleY 61.969
  }
 }
+$grp GenericEntity : "{CC66836BF4E211F9}Prefabs/Props/Military/Camps/Duckboard_01.et" {
+ {
+  coords 1479.357 29.226 2273.27
+  angleY 150.636
+ }
+ {
+  coords 1475.754 29.226 2279.674
+  angleY 150.636
+ }
+ {
+  coords 1472.508 28.373 2268.877
+  angleY 60.829
+ }
+ {
+  coords 1477.567 29.226 2276.452
+  angleY 150.636
+ }
+ {
+  coords 1473.929 29.226 2282.918
+  angleY 150.636
+ }
+ {
+  coords 1475.583 28.373 2270.593
+  angleY 60.829
+ }
+ {
+  coords 1466.258 28.373 2265.389
+  angleY 60.829
+ }
+ {
+  coords 1481.148 29.226 2270.086
+  angleY 150.636
+ }
+ {
+  coords 1463.346 28.373 2263.764
+  angleY 60.829
+ }
+ {
+  coords 1469.348 28.373 2267.114
+  angleY 60.829
+ }
+ {
+  coords 1472.127 29.226 2286.121
+  angleY 150.636
+ }
+ {
+  coords 1470.786 29.226 2288.504
+  angleY 150.636
+ }
+ {
+  coords 1466.816 26.601 2260.089
+  angleY 61.713
+  angleZ -42.409
+ }
+ {
+  coords 1470.25 25.169 2261.409
+  angleY 61.713
+ }
+ {
+  coords 1472.71 25.169 2262.743
+  angleY 61.713
+ }
+}
+$grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker.et" {
+ {
+  coords 1530.482 20.438 2211.855
+  angleY 0
+  m_MarkerColor 0 0.125 0.502 1
+  m_sQuadName "dot"
+  m_sDescription "Cut off"
+  m_aVisibleForFactions {
+   "RHS_USAF"
+  }
+ }
+ {
+  coords 1479.314 20.312 2182.776
+  angleY 0
+  m_MarkerColor 0 0.125 0.502 1
+  m_sQuadName "dot"
+  m_sDescription "Cut off"
+  m_aVisibleForFactions {
+   "RHS_USAF"
+  }
+ }
+}
 GenericEntity : "{CEA239D9E1899899}Prefabs/Props/Garbage/Tires/TirePile_01_small.et" {
  coords 1483.842 20.656 2224.249
 }
@@ -579,6 +858,36 @@ GenericEntity : "{CFB893B8084ECD2B}Prefabs/Props/Furniture/Armchair_01.et" {
  angleX 40.028
  angleY 180
  angleZ -180
+}
+$grp GenericEntity : "{D2299274C13B1169}PrefabsEditable/Auto/Props/Military/Sandbags/E_Sandbag_01_wall_solid_burlap.et" {
+ {
+  coords 1482.914 20.846 2219.707
+  angleY -28.569
+ }
+ {
+  coords 1473.344 24.146 2219.839
+  angleY 62.065
+ }
+ {
+  coords 1482.815 24.146 2219.47
+  angleY -26.33
+ }
+ {
+  coords 1474.672 24.146 2217.223
+  angleY 62.065
+ }
+ {
+  coords 1469.524 24.146 2227.044
+  angleY 62.065
+ }
+ {
+  coords 1467.7 24.146 2230.483
+  angleY 62.065
+ }
+ {
+  coords 1471.375 24.146 2223.553
+  angleY 62.065
+ }
 }
 $grp GenericEntity : "{D616AD4600D1311D}PrefabLibrary/Props/Industrial/WoodenPalletBox_01_Wood.et" {
  {
@@ -626,6 +935,16 @@ $grp GenericEntity : "{E7117284012B39A4}Prefabs/Props/Garbage/Bins/TrashBin_02_p
 GenericEntity : "{EBADB1F097DFAE02}PrefabsEditable/Auto/Props/Industrial/Repair/E_VehicleGarbage_01_pile_large.et" {
  coords 1471.063 20.656 2260.387
  angleY -26.598
+}
+$grp SCR_DestructibleBuildingEntity : "{EF96889E35217E1E}Prefabs/Structures/Houses/Shed/Shed_03/Shed_03_wide.et" {
+ {
+  coords 1479.745 -0.277 2253.258
+  angleY 61.005
+ }
+ {
+  coords 1476.108 -0.321 2251.192
+  angleY -118.16
+ }
 }
 $grp GenericEntity : "{F4EC6F567BBB6D70}PrefabsEditable/Auto/Structures/Infrastructure/Lamps/LampStreet_E_03/E_LampStreet_E_03_single.et" {
  {
@@ -720,4 +1039,15 @@ $grp GenericEntity : "{F4EC6F567BBB6D70}PrefabsEditable/Auto/Structures/Infrastr
   coords 1385.699 -0.024 2346.591
   angleY 62.657
  }
+ {
+  coords 1465.623 -0.037 2309.63
+  angleY 58.883
+ }
+}
+SCR_DestructibleBuildingEntity : "{F640FDB4D1AAF0BD}PrefabLibrary/Props/Civilian/Recreation/Caravan_03.et" {
+ coords 1482.721 20.656 2264.561
+ angleY 60.225
+}
+SCR_DestructibleBuildingEntity : "{F7919E01B9B17B3E}Prefabs/Structures/Ruins/HouseRuins/HouseRuin_01/HouseRuin_01_BrickPile_Small.et" {
+ coords 1479.616 0.106 2244.354
 }

--- a/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/Players.layer
+++ b/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/Players.layer
@@ -24,7 +24,7 @@ SCR_AIGroup : "{707D43629B9C7BFA}Prefabs/Groups/BLUFOR/US/Rangers 2009/P/Group_R
  coords 1583.729 20.73 2133.021
  angleY -58.973
  m_aUnitPrefabSlots {
-  "{25FECB70EBFE3EDA}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_SL_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{AA3790BBEF97F183}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_MG_P.et" "{66EFFAE3C5754A7A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_MGAS_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{AA3790BBEF97F183}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_MG_P.et" "{66EFFAE3C5754A7A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_MGAS_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{AA3790BBEF97F183}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_MG_P.et" "{66EFFAE3C5754A7A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_MGAS_P.et"
+  "{25FECB70EBFE3EDA}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_SL_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{AA3790BBEF97F183}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_MG_P.et" "{66EFFAE3C5754A7A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_MGAS_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{AA3790BBEF97F183}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_MG_P.et" "{66EFFAE3C5754A7A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_MGAS_P.et" "{474B263A266F57EF}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_ATTL_P.et" "{828A09BDBD765804}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_AT_P.et" "{C440E92966832FF3}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_ATAS_P.et"
  }
  m_sCustomNameSet "Ranger Weapons Squad"
 }
@@ -41,6 +41,9 @@ $grp SCR_AIGroup : "{9FA44AED55972EA9}Prefabs/Groups/BLUFOR/US/Rangers 2009/P/Gr
   }
   coords 1583.42 17.851 2109.604
   angleY -123.085
+  m_aUnitPrefabSlots {
+   "{25FECB70EBFE3EDA}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_SL_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{2A10FBA1AE4CA314}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_GR_P.et" "{3F5A5B3AC26D441A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_AR_P.et" "{D9936548CBBAA1CD}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_RF_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{2A10FBA1AE4CA314}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_GR_P.et" "{3F5A5B3AC26D441A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_AR_P.et" "{D9936548CBBAA1CD}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_RF_P.et"
+  }
  }
  {
   components {
@@ -54,6 +57,9 @@ $grp SCR_AIGroup : "{9FA44AED55972EA9}Prefabs/Groups/BLUFOR/US/Rangers 2009/P/Gr
   }
   coords 1601.049 19.368 2130.175
   angleY 54.287
+  m_aUnitPrefabSlots {
+   "{25FECB70EBFE3EDA}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_SL_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{2A10FBA1AE4CA314}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_GR_P.et" "{3F5A5B3AC26D441A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_AR_P.et" "{D9936548CBBAA1CD}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_RF_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{2A10FBA1AE4CA314}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_GR_P.et" "{3F5A5B3AC26D441A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_AR_P.et" "{D9936548CBBAA1CD}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_RF_P.et"
+  }
  }
  {
   components {
@@ -67,18 +73,27 @@ $grp SCR_AIGroup : "{9FA44AED55972EA9}Prefabs/Groups/BLUFOR/US/Rangers 2009/P/Gr
   }
   coords 1602.524 17.892 2108.026
   angleY 136.567
+  m_aUnitPrefabSlots {
+   "{25FECB70EBFE3EDA}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_SL_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{2A10FBA1AE4CA314}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_GR_P.et" "{3F5A5B3AC26D441A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_AR_P.et" "{D9936548CBBAA1CD}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_RF_P.et" "{4859D3B18F5C5472}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_TL_P.et" "{2A10FBA1AE4CA314}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_GR_P.et" "{3F5A5B3AC26D441A}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_AR_P.et" "{D9936548CBBAA1CD}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/RHS_USAF_RANGER/2009/P/Character_RHS_RANGER_09_RF_P.et"
+  }
  }
 }
 SCR_AIGroup : "{C9426F8783461162}Prefabs/Groups/OPFOR/RHS_AFRF/MSV/Flora/P/Group_RHS_RF_MSV_Flora_LightFireTeam_P.et" {
  components {
+  AIFormationComponent "{507E9DC12F541FE6}" {
+   DefaultFormation "line"
+  }
   PS_GroupCallsignAssigner "{65074006DC7DA618}" {
    m_iCompanyCallsign 3
    m_iPlatoonCallsign 3
    m_iSquadCallsign 3
   }
  }
- coords 1479.476 20.656 2249.415
- angleY 152.459
+ coords 1479.834 20.656 2248.427
+ angleY -123.949
+ m_aUnitPrefabSlots {
+  "{3A523970F07B0F3B}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/MSV/Flora/P/reduced gear/Character_RHS_RF_MSV_Flora_SR_P_2.et" "{2D0B5350E6734CE9}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/MSV/Flora/P/reduced gear/Character_RHS_RF_MSV_Flora_Rifleman_P_2.et" "{2D0B5350E6734CE9}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/MSV/Flora/P/reduced gear/Character_RHS_RF_MSV_Flora_Rifleman_P_2.et" "{2D0B5350E6734CE9}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/MSV/Flora/P/reduced gear/Character_RHS_RF_MSV_Flora_Rifleman_P_2.et"
+ }
 }
 SCR_AIGroup : "{D05ABE9D4FCD367E}Prefabs/Groups/OPFOR/RHS_AFRF/MSV/Flora/P/Group_RHS_RF_MSV_Flora_RifleSquad_P.et" {
  components {
@@ -93,4 +108,7 @@ SCR_AIGroup : "{D05ABE9D4FCD367E}Prefabs/Groups/OPFOR/RHS_AFRF/MSV/Flora/P/Group
  }
  coords 1452.969 20.656 2288.413
  angleY 59.883
+ m_aUnitPrefabSlots {
+  "{8075CDB9BC6C1814}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/MSV/Flora/P/reduced gear/Character_RHS_RF_MSV_Flora_SL_P_2.et" "{6EE5828193F15137}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/MSV/Flora/P/reduced gear/Character_RHS_RF_MSV_Flora_AR_P_2.et" "{2D0B5350E6734CE9}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/MSV/Flora/P/reduced gear/Character_RHS_RF_MSV_Flora_Rifleman_P_2.et" "{49BBE6BC855F0094}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/MSV/Flora/P/reduced gear/Character_RHS_RF_MSV_Flora_AT_P_2.et" "{3A523970F07B0F3B}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/MSV/Flora/P/reduced gear/Character_RHS_RF_MSV_Flora_SR_P_2.et" "{2D0B5350E6734CE9}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/MSV/Flora/P/reduced gear/Character_RHS_RF_MSV_Flora_Rifleman_P_2.et"
+ }
 }

--- a/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/Players.layer
+++ b/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/Players.layer
@@ -82,6 +82,9 @@ SCR_AIGroup : "{C9426F8783461162}Prefabs/Groups/OPFOR/RHS_AFRF/MSV/Flora/P/Group
 }
 SCR_AIGroup : "{D05ABE9D4FCD367E}Prefabs/Groups/OPFOR/RHS_AFRF/MSV/Flora/P/Group_RHS_RF_MSV_Flora_RifleSquad_P.et" {
  components {
+  AIFormationComponent "{507E9DC12F541FE6}" {
+   DefaultFormation "line"
+  }
   PS_GroupCallsignAssigner "{65074006D4144831}" {
    m_iCompanyCallsign 3
    m_iPlatoonCallsign 3

--- a/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/default.layer
+++ b/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/default.layer
@@ -13,6 +13,8 @@ PS_GameModeCoop PS_GameMode_Lobby_TILWMF1 : "{4CFD54745CD45673}Prefabs/MP/Modes/
   SCR_TimeAndWeatherHandlerComponent "{5EE3229927D4D2F5}" {
    m_iStartingHours 5
    m_iStartingMinutes 36
+   m_fDayTimeAcceleration 0.1
+   m_fNightTimeAcceleration 0.1
    m_bUseSpecifiedDate 1
    m_iSetDay 9
    m_iSetMonth 4
@@ -22,11 +24,27 @@ PS_GameModeCoop PS_GameMode_Lobby_TILWMF1 : "{4CFD54745CD45673}Prefabs/MP/Modes/
    m_fLongitude 37.921
    m_bOverrideTimeZoneInfo 1
    m_fDSTEnabled 1
-   m_fWind 5
+   m_fFogDensity 50
+   m_fFogHeight 150
+   m_fWind 10
   }
  }
  coords 1601.722 20.219 2178.804
- m_iFreezeTime 420000
+ m_iFreezeTime 60000
+}
+Vehicle S105_randomized7 : "{128253A267BE9424}Prefabs/Vehicles/Wheeled/S105/S105_randomized.et" {
+ components {
+  SCR_FuelManagerComponent "{5622A70CD78A9E2C}" {
+   FuelNodes {
+    SCR_FuelNode "{5622A70CD4036C5A}" {
+     MaxFuel 0
+     m_fInitialFuelTankState 0
+    }
+   }
+  }
+ }
+ coords 1458.964 20.656 2275.071
+ angleY 3.904
 }
 $grp Vehicle : "{36EA87CEC1BE77E0}Prefabs/Vehicles/Wheeled/JLTV/OGPK/M2HB/JLTV_OGPK_Olive.et" {
  JLTV_OGPK_Olive1 {
@@ -156,7 +174,7 @@ $grp Vehicle : "{36EA87CEC1BE77E0}Prefabs/Vehicles/Wheeled/JLTV/OGPK/M2HB/JLTV_O
     }
    }
   }
-  coords 1533.337 20.442 2213.118
+  coords 1533.622 20.442 2212.604
   angleY -29.054
  }
  JLTV_OGPK_Olive4 {
@@ -203,8 +221,47 @@ $grp Vehicle : "{36EA87CEC1BE77E0}Prefabs/Vehicles/Wheeled/JLTV/OGPK/M2HB/JLTV_O
   angleY -29.054
  }
 }
-SCR_EditorRestrictionZoneEntity : "{6144B0BE2EAC6897}PrefabsEditable/RestrictionZone/E_EditorRestrictionZoneMedium.et" {
- coords 1593.733 19.178 2124.212
+Vehicle S1203_transport_randomized1 : "{49C909AFD66E90A1}Prefabs/Vehicles/Wheeled/S1203/S1203_transport_randomized.et" {
+ components {
+  SCR_FuelManagerComponent "{5622A70CD78A9E2C}" {
+   FuelNodes {
+    SCR_FuelNode "{5622A70CD4036C5A}" {
+     m_fInitialFuelTankState 0
+    }
+   }
+  }
+ }
+ coords 1491.396 20.656 2236.255
+ angleY -28.41
+}
+Vehicle JLTV_Unarmed_Olive1 : "{59C895043D862E4F}Prefabs/Vehicles/Wheeled/JLTV/Unarmed/JLTV_Unarmed_Olive.et" {
+ components {
+  SCR_FuelManagerComponent "{5622A70CD78A9E2C}" {
+   FuelNodes {
+    SCR_FuelNode "{5622A70CD4036C5A}" {
+     m_fInitialFuelTankState 100
+    }
+   }
+  }
+  SCR_UniversalInventoryStorageComponent "{5C946CE5223089AE}" {
+   MultiSlots {
+    MultiSlotConfiguration "{650C116F71ADF097}" {
+     SlotTemplate InventoryStorageSlot smokes {
+      Prefab "{96FFE213B19D1D57}Prefabs/Weapons/Grenades/Smoke_No80_WP.et"
+     }
+     NumSlots 30
+    }
+    MultiSlotConfiguration "{650C11706943FAD3}" {
+     SlotTemplate InventoryStorageSlot ladder {
+      Prefab "{62F304402A707F68}Prefabs/Items/Equipment/TacticalLadder/ACE_TacticalLadder.et"
+     }
+     NumSlots 8
+    }
+   }
+  }
+ }
+ coords 1579.776 20.181 2139.829
+ angleY -129.98
 }
 $grp PolylineShapeEntity : "{85222A2744768C81}Prefabs/Logic/AOLimit/TILW_AOLimit.et" {
  bluforAO {
@@ -237,10 +294,16 @@ $grp PolylineShapeEntity : "{85222A2744768C81}Prefabs/Logic/AOLimit/TILW_AOLimit
     Position -34.129 0 160.696
    }
    ShapePoint "{65069363616E1C0C}" {
-    Position 35.57 0 36.634
+    Position 26.331 0 54.245
+   }
+   ShapePoint "{650C1160FB5661AA}" {
+    Position 37.7 0 59.914
+   }
+   ShapePoint "{650C1160E62F5F50}" {
+    Position 45.81 0 48.02
    }
    ShapePoint "{650693636E69E7B3}" {
-    Position 120.809 0 33.438
+    Position 91.388 0 41.094
    }
    ShapePoint "{6506936368C99F66}" {
     Position 171.411 0 -85.897
@@ -294,41 +357,14 @@ $grp PolylineShapeEntity : "{85222A2744768C81}Prefabs/Logic/AOLimit/TILW_AOLimit
   LineColor 0.502 0 0 1
  }
 }
-TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramework.et" {
- coords 1581.825 20.219 2163.665
- m_missionEvents {
-  TILW_MissionEvent "{6508D983AB223731}" {
-   m_instructions {
-    TILW_EndGameInstruction "{65069348739519D9}" {
-     m_executionDelay 10
-     m_factionKey "RHS_USAF"
-    }
-   }
-   m_condition TILW_LiteralTerm "{650693486309A08D}" {
-    m_flagName "ruloss"
-   }
-  }
-  TILW_MissionEvent "{6508D983AB010064}" {
-   m_instructions {
-    TILW_EndGameInstruction "{65069348969E23B6}" {
-     m_executionDelay 10
-     m_factionKey "RHS_AFRF"
-    }
-   }
-   m_condition TILW_LiteralTerm "{65069348934167CA}" {
-    m_flagName "usloss"
-   }
-  }
+$grp ParticleEffectEntity : "{C4A16F2433002F7E}Prefabs/Systems/Smoke/Wrapper_Smoke_Inf_Black_Large.et" {
+ {
+  coords 1518.405 21.908 2244.089
  }
- m_casualtyFlags {
-  TILW_FactionPlayersKilledFlag "{6508D983B68DAC36}" {
-   m_flagName "ruloss"
-   m_factionKey "RHS_AFRF"
-  }
-  TILW_FactionAIKilledFlag "{6508D983B978509E}" {
-   m_flagName "usloss"
-   m_factionKey "RHS_USAF"
-   m_casualtyRatio 0.9
-  }
+ {
+  coords 1521.538 21.852 2211.588
+ }
+ {
+  coords 1428.522 22.071 2269.871
  }
 }

--- a/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/default.layer
+++ b/worlds/Corax/Breach and clear/Breach_and_Clear_Layers/default.layer
@@ -12,9 +12,7 @@ PS_GameModeCoop PS_GameMode_Lobby_TILWMF1 : "{4CFD54745CD45673}Prefabs/MP/Modes/
   }
   SCR_TimeAndWeatherHandlerComponent "{5EE3229927D4D2F5}" {
    m_iStartingHours 5
-   m_iStartingMinutes 36
-   m_fDayTimeAcceleration 0.1
-   m_fNightTimeAcceleration 0.1
+   m_iStartingMinutes 30
    m_bUseSpecifiedDate 1
    m_iSetDay 9
    m_iSetMonth 4


### PR DESCRIPTION
- reduced equipment flora russians added (no Etool for you)
- replaced RU AT assistant with an AR 
- replaced ranger line squad M240 with M249
- replaced 1 weapons squad MG team with a MAAWS team
- green helmets for rangers
- added JLTV supply with 30 WP smokes and 8 assault ladders
- slightly widened initial funnel AO limit
- great reduce long range LOS for RU on initial break in
- added more clutter to alley ways 
- added some props to reduce the ability for gamey rooftop stuff
- added some atmospheric smoke generators to wrecks
- reduced start up timer to 1 minute (got to go fast)
- fixed some wrong faction checks for the briefing