### PR TITLE
Fixed Callsigns and end conditions

### DIFF
--- a/worlds/FSM/Worlds/TVT66BlockBusters/TVT66BlockBusters_Layers/Framework.layer
+++ b/worlds/FSM/Worlds/TVT66BlockBusters/TVT66BlockBusters_Layers/Framework.layer
@@ -89,7 +89,18 @@ PS_GameModeCoop PS_GameMode_Lobby_TILWMF1 : "{4CFD54745CD45673}Prefabs/MP/Modes/
     }
     SCR_Faction "{62EB308733CA83DD}" {
      m_CallsignInfo SCR_FactionCallsignInfo "{60A6B21E18F28741}" {
-      m_sCallsignGroupFormat ""
+      m_aSquadNames {
+       SCR_CallsignInfo "{58B2B630FDD64B6D}" {
+        m_sCallsign "Sparta"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B53}" {
+        m_sCallsign "Somalia"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B51}" {
+        m_sCallsign "Strelkov"
+       }
+      }
+      m_sCallsignGroupFormat "%3"
       m_sCallsignCharacterFormat ""
       m_sCallsignCharacterWithRoleFormat ""
      }
@@ -97,8 +108,14 @@ PS_GameModeCoop PS_GameMode_Lobby_TILWMF1 : "{4CFD54745CD45673}Prefabs/MP/Modes/
     SCR_Faction "{64AA098AEA5B1498}" {
      m_CallsignInfo SCR_FactionCallsignInfo "{64AA098204A61453}" {
       m_aSquadNames {
-       SCR_CallsignInfo "{64B8ED8EAACA8245}" {
+       SCR_CallsignInfo "{55CCB792D10AD8F4}" {
+        m_sCallsign ""
+       }
+       SCR_CallsignInfo "{61677618371B4C91}" {
         m_sCallsign "Delta"
+       }
+       SCR_CallsignInfo "{64B8ED8EAACA8245}" {
+        m_sCallsign "Whisky"
        }
       }
      }
@@ -247,8 +264,8 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   coords 2924.336 215.172 13081.195
   m_sTitle "End Conditions"
   m_sTextData "End Conditions:"\
-  "Canadians takes 90% casualties, Russian victory. Mission will end in 3 minutes or a GM can end it prior."\
-  "Separatists take 100% Casualties, Canadian Victory. Mission will end instantly."\
+  "Canadians takes 85% casualties, Separatist victory. Mission will end in 3 minutes or a GM can end it prior."\
+  "Separatists take 90% Casualties, Canadian Victory. Mission will end instantly."\
   "Canadians captures the objective, Canadian victory. Mission will end instantly."\
   ""\
   "Setup timer: 2 minutes"\
@@ -377,10 +394,10 @@ TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramewor
    m_instructions {
     TILW_SendMessageInstruction "{64A4F12F2711FB79}" {
      m_messageTitle "CA VICTORY"
-     m_messageBody "The CAF have eliminated all the separatists."
+     m_messageBody "The CAF have eliminated most of the separatists. The Mission will end in 3 minutes or the GM can end it. "
     }
     TILW_EndGameInstruction "{6490091469B3C8AF}" {
-     m_executionDelay 15
+     m_executionDelay 180
      m_factionKey "GC_CAF"
     }
    }
@@ -409,11 +426,12 @@ TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramewor
   TILW_FactionPlayersKilledFlag "{64A047FD08B987FC}" {
    m_flagName "Blufor Killed"
    m_factionKey "GC_CAF"
-   m_casualtyRatio 0.9
+   m_casualtyRatio 0.85
   }
   TILW_FactionPlayersKilledFlag "{64A047FD09D0EEA1}" {
    m_flagName "OPFOR Killed"
    m_factionKey "GC_SEPARATIST"
+   m_casualtyRatio 0.9
   }
  }
 }

--- a/worlds/FSM/Worlds/TVT66BlockBusters/TVT66BlockBusters_Layers/Players.layer
+++ b/worlds/FSM/Worlds/TVT66BlockBusters/TVT66BlockBusters_Layers/Players.layer
@@ -1,31 +1,60 @@
-SCR_AIGroup : "{3328392DDCAB9973}Prefabs/Groups/BLUFOR/Canadian_Army_RHS/Group_RHSCAF_PlatoonHQ_P.et" {
+SCR_AIGroup : "{3328392DDCAB9973}Prefabs/Groups/BLUFOR/GC_CAF/RHS Canadian Army/Group_RHSCAF_PlatoonHQ_P.et" {
+ components {
+  PS_GroupCallsignAssigner "{653261C4295A0215}" {
+  }
+ }
  coords 3448.546 274.836 12021.81
  m_aUnitPrefabSlots {
-  "{7E4D56AE455431C2}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_Platoon_Commander_CW.et" "{350935F7D7537ADF}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_Platoon_Warrant_CW.et" "{7043F1353E10A8B8}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_Medic_CW.et" "{7043F1353E10A8B8}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_Medic_CW.et"
+  "{7E4D56AE455431C2}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_Platoon_Commander_CW.et" "{350935F7D7537ADF}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_Platoon_Warrant_CW.et" "{7043F1353E10A8B8}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_Medic_CW.et" "{7043F1353E10A8B8}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_Medic_CW.et"
  }
  m_sCustomNameSet "Platoon Headquarters - 11"
 }
-$grp SCR_AIGroup : "{4A75FE2125C6F2CE}Prefabs/Groups/BLUFOR/Canadian_Army_RHS/Group_RHSCAF_RifleSection_P.et" {
+$grp SCR_AIGroup : "{4A75FE2125C6F2CE}Prefabs/Groups/BLUFOR/GC_CAF/RHS Canadian Army/Group_RHSCAF_RifleSection_P.et" {
  {
+  components {
+   PS_GroupCallsignAssigner "{653261C45F131A82}" {
+    m_iSquadCallsign 1
+   }
+  }
   coords 3451.458 265.385 12100.174
   m_sCustomNameSet "1st Section - 11A"
  }
  {
+  components {
+   PS_GroupCallsignAssigner "{653261C42C275E15}" {
+    m_iSquadCallsign 2
+   }
+  }
   coords 3444.579 269.788 12058.694
   m_sCustomNameSet "Second Section - 11B"
  }
  {
+  components {
+   PS_GroupCallsignAssigner "{653261C43408DE41}" {
+    m_iSquadCallsign 3
+   }
+  }
   coords 3475.232 268.985 12088.038
   m_sCustomNameSet "Third Section - 11C"
  }
  {
+  components {
+   PS_GroupCallsignAssigner "{653261C402BE288C}" {
+    m_iSquadCallsign 4
+   }
+  }
   coords 3438.76 271.805 12036.814
   m_sCustomNameSet "Fourth Section - 11D"
  }
  {
+  components {
+   PS_GroupCallsignAssigner "{653261C405135328}" {
+    m_iSquadCallsign 5
+   }
+  }
   coords 3478.544 273.419 12051.994
   m_aUnitPrefabSlots {
-   "{58EA7492CFF225F1}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_1IC_CW.et" "{10A074DDE11AF991}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_MG_CW.et" "{282D3AEC0BCB0357}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_MG2_CW.et" "{10A074DDE11AF991}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_MG_CW.et" "{282D3AEC0BCB0357}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_MG2_CW.et" "{2402540EFD5A2BDE}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_2IC_CW.et" "{8027796B1E2D9559}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_AT1_CW.et" "{8A822926A83D66DE}Prefabs/Characters/Factions/BLUFOR/RHS_Canada/Character_CAF_AT2_CW.et"
+   "{58EA7492CFF225F1}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_1IC_CW.et" "{10A074DDE11AF991}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_MG_CW.et" "{282D3AEC0BCB0357}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_MG2_CW.et" "{10A074DDE11AF991}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_MG_CW.et" "{282D3AEC0BCB0357}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_MG2_CW.et" "{2402540EFD5A2BDE}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_2IC_CW.et" "{8027796B1E2D9559}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_AT1_CW.et" "{8A822926A83D66DE}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_AT2_CW.et"
   }
   m_sCustomNameSet "Weapon Detachment - 11W"
  }

--- a/worlds/FSM/Worlds/TVT66ZherebetsRiverCache/TVT66ZherebetsRiverCache_Layers/Framework.layer
+++ b/worlds/FSM/Worlds/TVT66ZherebetsRiverCache/TVT66ZherebetsRiverCache_Layers/Framework.layer
@@ -55,12 +55,11 @@ PS_GameModeCoop PS_GameMode_Lobby_TILWMF1 : "{4CFD54745CD45673}Prefabs/MP/Modes/
      m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A6677ADA9E}" {
       m_aCompanyNames {
        SCR_CallsignInfo "{55CCB792CD021D5C}" {
-        m_sCallsign " "
+        m_sCallsign "1"
        }
       }
       m_aPlatoonNames {
        SCR_CallsignInfo "{55CCB792CE6E998D}" {
-        m_sCallsign " "
        }
       }
       m_aSquadNames {
@@ -111,10 +110,15 @@ PS_GameModeCoop PS_GameMode_Lobby_TILWMF1 : "{4CFD54745CD45673}Prefabs/MP/Modes/
        SCR_CallsignInfo "{55CCB792D10AD8F4}" {
         m_sCallsign ""
        }
+       SCR_CallsignInfo "{55CCB792D0C8B3CE}" {
+       }
        SCR_CallsignInfo "{61677618371B4C91}" {
         m_sCallsign "Delta"
        }
        SCR_CallsignInfo "{650C2501D1BDE0D5}" {
+        m_sCallsign "Whisky"
+       }
+       SCR_CallsignInfo "{653261C6A8B773E7}" {
         m_sCallsign "Whisky"
        }
       }
@@ -415,7 +419,7 @@ TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramewor
   TILW_FactionPlayersKilledFlag "{64A047FE5DE1CD51}" {
    m_flagName "Blufor Killed"
    m_factionKey "GC_CAF"
-   m_casualtyRatio 0.9
+   m_casualtyRatio 0.85
   }
   TILW_FactionPlayersKilledFlag "{64A047FE52FADD9F}" {
    m_flagName "OPFOR Killed"

--- a/worlds/FSM/Worlds/TVT66ZherebetsRiverCache/TVT66ZherebetsRiverCache_Layers/Players.layer
+++ b/worlds/FSM/Worlds/TVT66ZherebetsRiverCache/TVT66ZherebetsRiverCache_Layers/Players.layer
@@ -1,4 +1,4 @@
-SCR_AIGroup : "{3328392DDCAB9973}Prefabs/Groups/BLUFOR/GC_Canada/Canadian_Army_RHS/Group_RHSCAF_PlatoonHQ_P.et" {
+SCR_AIGroup : "{3328392DDCAB9973}Prefabs/Groups/BLUFOR/GC_CAF/RHS Canadian Army/Group_RHSCAF_PlatoonHQ_P.et" {
  components {
   PS_GroupCallsignAssigner "{650C25018F5A4184}" {
   }
@@ -9,7 +9,7 @@ SCR_AIGroup : "{3328392DDCAB9973}Prefabs/Groups/BLUFOR/GC_Canada/Canadian_Army_R
  }
  m_sCustomNameSet "Platoon Headquarters - 11"
 }
-$grp SCR_AIGroup : "{4A75FE2125C6F2CE}Prefabs/Groups/BLUFOR/GC_Canada/Canadian_Army_RHS/Group_RHSCAF_RifleSection_P.et" {
+$grp SCR_AIGroup : "{4A75FE2125C6F2CE}Prefabs/Groups/BLUFOR/GC_CAF/RHS Canadian Army/Group_RHSCAF_RifleSection_P.et" {
  {
   components {
    PS_GroupCallsignAssigner "{650C25019142AC8F}" {
@@ -17,7 +17,7 @@ $grp SCR_AIGroup : "{4A75FE2125C6F2CE}Prefabs/Groups/BLUFOR/GC_Canada/Canadian_A
    }
   }
   coords 3787.409 15.052 627.321
-  m_sCustomNameSet "1st Section - 11A"
+  m_sCustomNameSet "1 Section - 11A"
  }
  {
   components {
@@ -26,7 +26,7 @@ $grp SCR_AIGroup : "{4A75FE2125C6F2CE}Prefabs/Groups/BLUFOR/GC_Canada/Canadian_A
    }
   }
   coords 3829.719 17.047 596.588
-  m_sCustomNameSet "Second Section - 11B"
+  m_sCustomNameSet "2 Section - 11B"
  }
  {
   components {
@@ -35,7 +35,7 @@ $grp SCR_AIGroup : "{4A75FE2125C6F2CE}Prefabs/Groups/BLUFOR/GC_Canada/Canadian_A
    }
   }
   coords 3841.84 14.844 631.802
-  m_sCustomNameSet "Third Section - 11C"
+  m_sCustomNameSet "3 Section - 11C"
  }
  {
   components {
@@ -44,7 +44,7 @@ $grp SCR_AIGroup : "{4A75FE2125C6F2CE}Prefabs/Groups/BLUFOR/GC_Canada/Canadian_A
    }
   }
   coords 3856.969 15.187 614.833
-  m_sCustomNameSet "Fourth Section - 11D"
+  m_sCustomNameSet "4 Section - 11D"
  }
  {
   components {
@@ -56,7 +56,7 @@ $grp SCR_AIGroup : "{4A75FE2125C6F2CE}Prefabs/Groups/BLUFOR/GC_Canada/Canadian_A
   m_aUnitPrefabSlots {
    "{58EA7492CFF225F1}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_1IC_CW.et" "{10A074DDE11AF991}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_MG_CW.et" "{282D3AEC0BCB0357}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_MG2_CW.et" "{10A074DDE11AF991}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_MG_CW.et" "{282D3AEC0BCB0357}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_MG2_CW.et" "{2402540EFD5A2BDE}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_2IC_CW.et" "{10A074DDE11AF991}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_MG_CW.et" "{282D3AEC0BCB0357}Prefabs/Characters/Factions/BLUFOR/GC_Canada/RHS_Canada/Character_CAF_MG2_CW.et"
   }
-  m_sCustomNameSet "Weapon Detachment - 11W"
+  m_sCustomNameSet "Weapons Detachment - 11W"
  }
 }
 SCR_AIGroup : "{BB49EA4063459740}worlds/FSM/Prefabs/Groups/OPFOR/Seperatists/P/FSM_Playable_Seperatists_HQ.et" {

--- a/worlds/FSM/Worlds/TVTBarrackHoldout/TVT67BarrackHoldout_Layers/Framework.layer
+++ b/worlds/FSM/Worlds/TVTBarrackHoldout/TVT67BarrackHoldout_Layers/Framework.layer
@@ -89,7 +89,27 @@ PS_GameModeCoop PS_GameMode_Lobby_TILWMF1 : "{4CFD54745CD45673}Prefabs/MP/Modes/
     }
     SCR_Faction "{62EB308733CA83DD}" {
      m_CallsignInfo SCR_FactionCallsignInfo "{60A6B21E18F28741}" {
-      m_sCallsignGroupFormat ""
+      m_aSquadNames {
+       SCR_CallsignInfo "{58B2B630FDD64B6D}" {
+        m_sCallsign "Sparta"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B53}" {
+        m_sCallsign "Somalia"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B51}" {
+        m_sCallsign "Strelkov"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B50}" {
+        m_sCallsign "Motorola"
+       }
+       SCR_CallsignInfo "{61C8F1ACA9FDB12D}" {
+        m_sCallsign "Zelenegorsk"
+       }
+       SCR_CallsignInfo "{653267EBF9B94F5E}" {
+        m_sCallsign "Givi"
+       }
+      }
+      m_sCallsignGroupFormat "%3"
       m_sCallsignCharacterFormat ""
       m_sCallsignCharacterWithRoleFormat ""
      }
@@ -216,9 +236,9 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   coords 2924.336 215.172 13081.195
   m_sTitle "End Conditions"
   m_sTextData "End Conditions:"\
-  "Separatists take 90% casualties, Separatists victory. Mission will end in 3 minutes or a GM can end it prior."\
-  "CDFs take 100% Casualties, CDF Victory. Mission will end instantly."\
-  "Separatists captures the objective, Canadian victory. Mission will end instantly."\
+  "Separatists take 85% casualties, CF victory. Mission will end in 3 minutes or a GM can end it prior."\
+  "CDFs take 90% Casualties, Separatist Victory. Mission will end in 3 minutes or a GM can end it prior. "\
+  "Separatists captures the objective, Separatist victory. Mission will end instantly."\
   ""\
   "There is no overall CO for the Separatists. Sparta is in charge of the Sparta Platoon and Motorola is in charge of the Motorola platoon. However, both platoon leaders can work together."\
   ""\
@@ -340,10 +360,10 @@ TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramewor
    m_instructions {
     TILW_SendMessageInstruction "{64A4F12F2711FB79}" {
      m_messageTitle "Separatist VICTORY"
-     m_messageBody "The Separatist have eliminated all the CDF."
+     m_messageBody "The Separatists have killed most of the CDF. Mission will end in 3 minutes or the GM can end it prior. "
     }
     TILW_EndGameInstruction "{6490091469B3C8AF}" {
-     m_executionDelay 15
+     m_executionDelay 180
      m_factionKey "GC_SEPARATIST"
     }
    }
@@ -372,11 +392,12 @@ TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramewor
   TILW_FactionPlayersKilledFlag "{64A047FD08B987FC}" {
    m_flagName "Attackers Win"
    m_factionKey "GC_CDF"
+   m_casualtyRatio 0.9
   }
   TILW_FactionPlayersKilledFlag "{64A047FD09D0EEA1}" {
    m_flagName "Attackers Lose"
    m_factionKey "GC_SEPARATIST"
-   m_casualtyRatio 0.9
+   m_casualtyRatio 0.85
   }
  }
 }


### PR DESCRIPTION
Fixed the Canadian callsigns in 2 missions
Fixed Separatist callsigns in 3 missions
Changed defender end conditions from 100% to 90% with 3 minute timer with message that GM can end it sooner. 
Changed attacker end conditions from 90% to 85% with 3 minute timer with message that GM can end it sooner. 
Fixed Markers not appearing.

