### PR TITLE
COTVT (60-77) Battle For Rasman V2.0

### DIFF
--- a/Missions/HitTheMan/Battle For Rasman/BattleForRasman.conf
+++ b/Missions/HitTheMan/Battle For Rasman/BattleForRasman.conf
@@ -1,6 +1,6 @@
 SCR_MissionHeader {
  World "{76F18394736F2CC0}worlds/HitTheMan/Battle For Rasman/BattleForRasman.ent"
- m_sName "COTVT (60-77) Battle For Rasman V1.0"
+ m_sName "COTVT (60-77) Battle For Rasman V2.0"
  m_sAuthor "HitTheMan"
  m_sDescription "US Rifle Platoon (+) with Bradley Support move to secure the town of Rasman from Takistani Army of a Light Rifle Platoon & a BMP Platoon"
  m_sIcon "{9D4CFCE8D17759BF}Missions/HitTheMan/EastGermanBTR.edds"

--- a/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/Core/Civilians.layer
+++ b/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/Core/Civilians.layer
@@ -1,3 +1,6 @@
+SCR_AIWaypoint Civ_Move : "{06E1B6EBD480C6E0}Prefabs/AI/Waypoints/AIWaypoint_ForcedMove.et" {
+ coords 6796.715 68.75 11975.985
+}
 $grp SCR_DefendWaypoint : "{4ECD14650D82F5CA}Prefabs/AI/Waypoints/AIWaypoint_Loiter_CO.et" {
  Civ_loiter_1 {
   coords 6260.361 86.604 11256.935

--- a/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/Core/Props.layer
+++ b/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/Core/Props.layer
@@ -35,6 +35,10 @@ $grp GenericEntity : "{388B774519BD6294}Prefabs/Props/Wrecks/T62_wreck.et" {
   angleY -155.468
  }
 }
+GenericEntity : "{6BDDFE9FA1D4B2F0}Prefabs/Props/Wrecks/UAZ469_wreck.et" {
+ coords 6276.044 86.91 11206.721
+ angleY -178.123
+}
 GenericEntity : "{B66EE06D3F5749D6}worlds/FloridaMan/Prefabs/Setpeice/Wreck_AH64_Blackbox.et" {
  coords 6315.904 86.61 11208.438
  angleY -1.64
@@ -59,6 +63,306 @@ GenericEntity : "{B66EE06D3F5749D6}worlds/FloridaMan/Prefabs/Setpeice/Wreck_AH64
    ID "655B660447B37DCF"
    coords 0.051 2.607 -0.978
   }
+ }
+}
+$grp GenericEntity : "{B86FFB24E23D8055}PrefabsEditable/EffectsModules/Mine/EffectModule_MineField_Rect_Row_USSR.et" {
+ Tak_mine_1 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6380.614 87.384 11104.756
+  angleY -49.637
+ }
+ Tak_mine_2 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6383.635 91.348 11058.309
+  angleY -118.822
+ }
+ Tak_mine_3 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6333.814 92.565 11068.703
+  angleY -49.637
+ }
+ Tak_mine_4 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6292.45 92.541 11120.115
+  angleY -28.195
+ }
+ Tak_mine_5 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6273.123 86.958 11203.37
+  angleY -56.787
+ }
+ Tak_mine_6 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6218.578 86.696 11238.06
+  angleY -56.582
+ }
+ Tak_mine_7 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6185.986 86.328 11259.901
+  angleY -57.252
+ }
+ Tak_mine_8 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6188.701 93.1 11175.543
+  angleY -89.009
+ }
+ Tak_mine_9 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6058.71 95.094 11049.621
+  angleY -52.8
+ }
+ Tak_mine_10 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6170.057 92.422 10987.49
+  angleY -69.407
+ }
+ Tak_mine_11 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6308.778 93.157 10857.451
+  angleY -93.327
+ }
+ Tak_mine_12 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6121.158 92.819 10866.261
+  angleY -70.853
+ }
+ Tak_mine_13 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6310.15 93.188 10721.959
+  angleY -77.878
+ }
+ Tak_mine_14 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 20
+      m_fLength 100
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 70
+     m_iMaxProjectilesEachBarrage 70
+    }
+   }
+  }
+  coords 6453.647 87.371 11099.062
+  angleY -100.029
+ }
+ Tak_mine_15 {
+  components {
+   SCR_EffectsModuleComponent "{5CA2DE492D8BBCF5}" {
+    m_EffectConfig SCR_BarrageEffectsModule "{5D22CCE8F9AEE06D}" {
+     m_ModuleZoneData SCR_EffectsModulePositionData_Rectangle "{618EBC0A84615572}" {
+      m_fWidth 12
+      m_fLength 20
+      m_fDistanceSpreadPercentage 0.1
+      m_fMinimalDistanceBetweenPositions 2
+      m_fCenterBias 0
+      m_bSpawnInRow 0
+     }
+     m_iMinProjectilesEachBarrage 15
+     m_iMaxProjectilesEachBarrage 15
+    }
+   }
+  }
+  coords 6218.732 93.181 11118.232
+  angleY -60.513
  }
 }
 $grp ParticleEffectEntity : "{C4A16F2433002F7E}Prefabs/Systems/Smoke/Wrapper_Smoke_Inf_Black_Large.et" {
@@ -96,5 +400,211 @@ $grp ParticleEffectEntity : "{C4A16F2433002F7E}Prefabs/Systems/Smoke/Wrapper_Smo
  }
  {
   coords 6234.322 94.135 10871.078
+ }
+ {
+  coords 6276.134 87.616 11206.627
+  angleY -1.64
+ }
+}
+$grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker.et" {
+ Tak_Mark_Minefield_2 {
+  coords 6383.787 91.348 11058.116
+  angleY 61.739
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_3 {
+  coords 6333.689 92.563 11068.494
+  angleY 130.924
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_4 {
+  coords 6292.258 92.532 11119.968
+  angleY 152.365
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_5 {
+  coords 6273.025 86.946 11203.147
+  angleY 123.773
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_6 {
+  coords 6218.48 86.694 11237.838
+  angleY 123.979
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_7 {
+  coords 6185.889 86.328 11259.677
+  angleY 123.308
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_8 {
+  coords 6188.737 93.098 11175.302
+  angleY 91.551
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_9 {
+  coords 6058.597 95.092 11049.406
+  angleY 127.76
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_10 {
+  coords 6170.01 92.421 10987.251
+  angleY 111.154
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_11 {
+  coords 6308.832 93.155 10857.214
+  angleY 87.233
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_12 {
+  coords 6121.117 92.817 10866.021
+  angleY 109.707
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_bVisibleForEmptyFaction 1
+  m_bShowForAnyFaction 1
+ }
+ Tak_Mark_Minefield_13 {
+  coords 6310.139 93.186 10721.716
+  angleY 102.683
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_bVisibleForEmptyFaction 1
+  m_bShowForAnyFaction 1
+ }
+ Tak_Mark_Minefield_1 {
+  coords 6380.489 87.382 11104.547
+  angleY 130.924
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_14 {
+  coords 6422.276 87.634 11092.978
+  angleY 80.532
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 50
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_15 {
+  coords 6454.11 87.392 11098.151
+  angleY 80.532
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 50
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_16 {
+  coords 6486.72 87.328 11103.775
+  angleY 80.532
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 50
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_Minefield_17 {
+  coords 6218.649 93.169 11118.004
+  angleY 120.047
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mine-field"
+  m_fWorldSize 30
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
  }
 }

--- a/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/TAK_Players/AI_Def.layer
+++ b/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/TAK_Players/AI_Def.layer
@@ -1,3 +1,33 @@
+$grp SCR_AIGroup : "{5E24277419088E09}Prefabs/Groups/INDFOR/GC_TKA/Takistan Army 1992-2012 (TKA)/Group_GC_TKA_RifleSquad.et" {
+ Def_AI_1 {
+  coords 6228.864 93.186 10931.923
+  angleY -151.524
+  m_aStaticWaypoints {
+   "Def_wp_AI_1"
+  }
+ }
+ Def_AI_2 {
+  coords 6312.621 93.187 10968.038
+  angleY -151.524
+  m_aStaticWaypoints {
+   "Def_wp_AI_2"
+  }
+ }
+ Def_AI_3 {
+  coords 6332.055 93.188 10812.022
+  angleY -151.524
+  m_aStaticWaypoints {
+   "Def_wp_AI_3"
+  }
+ }
+ Def_AI_4 {
+  coords 6079.201 90.648 10986.915
+  angleY -151.524
+  m_aStaticWaypoints {
+   "Def_wp_AI_4"
+  }
+ }
+}
 $grp Tank : "{828E8711567C3242}Prefabs/Vehicles/Tracked/BMP1/BMP1P_FIA_Desert.et" {
  BMP1P_FIA_Desert3 {
   components {
@@ -25,8 +55,8 @@ $grp Tank : "{828E8711567C3242}Prefabs/Vehicles/Tracked/BMP1/BMP1P_FIA_Desert.et
     }
    }
   }
-  coords 6345.34 93.187 10789.138
-  angleY -147.797
+  coords 6307.532 93.151 10900.394
+  angleY -164.484
  }
  BMP1P_FIA_Desert2 {
   components {
@@ -85,7 +115,7 @@ $grp Tank : "{828E8711567C3242}Prefabs/Vehicles/Tracked/BMP1/BMP1P_FIA_Desert.et
     }
    }
   }
-  coords 5960.243 102.905 11078.566
+  coords 5959.622 103.355 11068.303
   angleX -5.18
   angleY 107.503
   angleZ -4.294
@@ -116,7 +146,25 @@ $grp Tank : "{828E8711567C3242}Prefabs/Vehicles/Tracked/BMP1/BMP1P_FIA_Desert.et
     }
    }
   }
-  coords 6315.775 86.156 11288.362
-  angleY -152.248
+  coords 6315.775 86.156 11288.361
+  angleY -165.712
+ }
+}
+$grp SCR_DefendWaypoint : "{93291E72AC23930F}Prefabs/AI/Waypoints/AIWaypoint_Defend.et" {
+ Def_wp_AI_1 {
+  coords 6231.444 93.187 10937.308
+  CompletionRadius 20
+ }
+ Def_wp_AI_2 {
+  coords 6315.303 93.188 10971.444
+  CompletionRadius 20
+ }
+ Def_wp_AI_3 {
+  coords 6334.073 93.187 10816.588
+  CompletionRadius 20
+ }
+ Def_wp_AI_4 {
+  coords 6082.235 90.634 10991.211
+  CompletionRadius 80
  }
 }

--- a/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/TAK_Players/TAK_Briefings.layer
+++ b/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/TAK_Players/TAK_Briefings.layer
@@ -33,6 +33,8 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   ""\
   "BMP Platoon located south in positions to support & delay the incoming american movement."\
   ""\
+  "INF Platoon located south to delay the enemy while we prep our defences"\
+  ""\
   "We used up our RPGs from earlier engagement, only have AT Mines at our disposal & BMP Platoon to deal with the Bradleys"\
   ""\
   "Higher Units Mission:"\
@@ -57,7 +59,9 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
  {
   coords 5810.876 272.451 10244.802
   m_sTitle "II. Mission:"
-  m_sTextData "Defend the town of Rasman from the American forces, by utilizing what Urban denseness there is, AT Mine placements and our Platoon of BMPs positioned south (Marked on map)"
+  m_sTextData "Defend the town of Rasman from the American forces, by utilizing what Urban denseness there is, AT Mine placements and our Platoon of BMPs positioned south (Marked on map) and a Inf PLT south as well delaying the enemy"\
+  ""\
+  "Beware UAZs will detonate the mines when the wheel makes contact with the mine (A squad from another PLT learned the hard way)"
   m_aVisibleForFactions {
    "GC_TKA"
   }
@@ -87,13 +91,16 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "None."\
   ""\
   "II. Logistical Support:"\
-  "30x AT Mines in the Ural near PLT HQ"\
+  "60x AT Mines in the UAZs combined near PLT HQ"\
+  "(20x In Each Vehicle)"\
+  "2x Alice Backpacks in each UAZ"\
   ""\
   "III. Medical:"\
   "None."\
   ""\
   "IV. Vehicles:"\
-  "1x Ural"
+  "2x UAZs"\
+  "1x UAZ UK59 Gun"
   m_aVisibleForFactions {
    "GC_TKA"
   }

--- a/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/TAK_Players/TAK_Markers.layer
+++ b/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/TAK_Players/TAK_Markers.layer
@@ -28,7 +28,7 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
   m_bringToFront 0
  }
  Tak_Mark_3 {
-  coords 5960.007 105.552 11078.748
+  coords 5958.619 104.833 11068.815
   angleY -162.123
   m_sImageSet "{83B695FF662AC163}imagesets/Soviet_Tactical_Graphics.imageset"
   m_sImageSetGlow ""
@@ -42,8 +42,8 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
   m_bringToFront 0
  }
  Tak_Mark_4 {
-  coords 6345.326 94.834 10789.063
-  angleY -59.111
+  coords 6307.219 94.713 10899.849
+  angleY -74.359
   m_sImageSet "{83B695FF662AC163}imagesets/Soviet_Tactical_Graphics.imageset"
   m_sImageSetGlow ""
   m_MarkerColor 0.561 0.071 0.071 1
@@ -190,6 +190,20 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
   m_sQuadName "bmp"
   m_fWorldSize 50
   m_sDescription "BMP"
+  m_aVisibleForFactions {
+   "GC_TKA"
+  }
+  m_bringToFront 0
+ }
+ Tak_Mark_15 {
+  coords 6243.387 93.189 10871.464
+  angleY 90
+  m_sImageSet "{83B695FF662AC163}imagesets/Soviet_Tactical_Graphics.imageset"
+  m_sImageSetGlow ""
+  m_MarkerColor 0.561 0.071 0.071 1
+  m_sQuadName "plt_hq"
+  m_fWorldSize 150
+  m_sDescription "234 (AI PLT)"
   m_aVisibleForFactions {
    "GC_TKA"
   }

--- a/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/TAK_Players/TAK_Players.layer
+++ b/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/TAK_Players/TAK_Players.layer
@@ -72,23 +72,6 @@ $grp SCR_AIGroup : "{7CBC157AA0058745}Prefabs/Groups/INDFOR/GC_TKA/Takistan Army
   }
  }
 }
-Vehicle Ural4320_FIA_transport_covered1 : "{B70E6D12A8EC2410}Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_FIA_transport_covered.et" {
- components {
-  SCR_UniversalInventoryStorageComponent "{5916C58171230A92}" {
-   MultiSlots {
-    MultiSlotConfiguration "{6568DE6255F0683A}" {
-     SlotTemplate InventoryStorageSlot Bandages {
-      Prefab "{D6EF54367CECE1D9}Prefabs/Weapons/Explosives/Mine_TM62M/Mine_TM62M.et"
-     }
-     NumSlots 20
-    }
-   }
-  }
- }
- coords 6340.339 86.821 11404.886
- angleY 120.392
- m_sAttachmentGroupName "TAK_PLTHQ_1"
-}
 SCR_AIGroup TAK_PLTHQ_1 : "{CA68C1FA21DF9212}Prefabs/Groups/INDFOR/GC_TKA/Takistan Army 1992-2012 (TKA)/P/Group_GC_TKA_PHQ_P.et" {
  components {
   AIFormationComponent "{507E9DC12F541FE6}" {
@@ -109,4 +92,72 @@ SCR_AIGroup TAK_PLTHQ_1 : "{CA68C1FA21DF9212}Prefabs/Groups/INDFOR/GC_TKA/Takist
  m_aUnitPrefabColorTeams {
   "Yellow" "Yellow" "Red" "Red"
  }
+}
+$grp Vehicle : "{E28501E93F8EFDC0}Prefabs/Vehicles/Wheeled/UAZ469/UAZ469_FIA_uncovered.et" {
+ UAZ469_FIA_uncovered1 {
+  components {
+   SCR_UniversalInventoryStorageComponent "{5AD4F813E67ECB5D}" {
+    MultiSlots {
+     MultiSlotConfiguration "{65717A59BD8053D9}" {
+      SlotTemplate InventoryStorageSlot Bandages {
+       Prefab "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+      }
+      NumSlots 2
+     }
+     MultiSlotConfiguration "{65717A5D9C2C4B78}" {
+      SlotTemplate InventoryStorageSlot Bandages {
+       Prefab "{D6EF54367CECE1D9}Prefabs/Weapons/Explosives/Mine_TM62M/Mine_TM62M.et"
+      }
+      NumSlots 20
+     }
+    }
+   }
+  }
+  coords 6338.774 86.824 11405.541
+  angleY 117.083
+ }
+ UAZ469_FIA_uncovered2 {
+  components {
+   SCR_UniversalInventoryStorageComponent "{5AD4F813E67ECB5D}" {
+    MultiSlots {
+     MultiSlotConfiguration "{65717A59B7E871A9}" {
+      SlotTemplate InventoryStorageSlot Bandages {
+       Prefab "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+      }
+      NumSlots 2
+     }
+     MultiSlotConfiguration "{65717A5D9C2C4B78}" {
+      SlotTemplate InventoryStorageSlot Bandages {
+       Prefab "{D6EF54367CECE1D9}Prefabs/Weapons/Explosives/Mine_TM62M/Mine_TM62M.et"
+      }
+      NumSlots 20
+     }
+    }
+   }
+  }
+  coords 6345.751 86.811 11401.867
+  angleY 117.083
+ }
+}
+Vehicle UAZ469_UK59_FIA1 : "{E72D78E7F45532EC}Prefabs/Vehicles/Wheeled/UAZ469/UAZ469_UK59_FIA.et" {
+ components {
+  SCR_UniversalInventoryStorageComponent "{5AD4F813E67ECB5D}" {
+   MultiSlots {
+    MultiSlotConfiguration "{65717A59AB1270FF}" {
+     SlotTemplate InventoryStorageSlot Bandages {
+      Prefab "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+     }
+     NumSlots 2
+    }
+    MultiSlotConfiguration "{65717A5DBF370941}" {
+     SlotTemplate InventoryStorageSlot Bandages {
+      Prefab "{D6EF54367CECE1D9}Prefabs/Weapons/Explosives/Mine_TM62M/Mine_TM62M.et"
+     }
+     NumSlots 12
+    }
+   }
+  }
+ }
+ coords 6352.694 86.813 11398.086
+ angleY 117.091
 }

--- a/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/US_Players/US_Brief.layer
+++ b/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/US_Players/US_Brief.layer
@@ -14,8 +14,8 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "12x Smoke Grenades"\
   "36x Stanags"\
   "6x M249 Belts"\
-  "2x Clacker"\
-  "8x Demo Charges"\
+  "4x Clacker"\
+  "16x Demo Charges"\
   "2x LAWs"\
   ""\
   "III. Medical:"\
@@ -41,8 +41,8 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "3rd Squad		- 2'3"\
   "4th Squad		- 2'4"\
   ""\
-  "1st Bradley		- 3'1v"\
-  "2nd Bradley		- 3'2v"\
+  "1st Bradley		- 3'1"\
+  "2nd Bradley		- 3'2"\
   ""\
   "III. Frequencies:"\
   "Platoon Nets		- 48.00"
@@ -128,7 +128,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTitle "II. Mission:"
   m_sTextData "Secure the town of Rasman from the Takistan Army to liberate the local populace and destroy the BMP & Infantry Platoons."\
   ""\
-  "Beware there are civilians in the area."
+  "Beware there are civilians in the area and minefields, the PLT to our north found two minefields marked on map but they'll likely have more placed"
   m_aVisibleForFactions {
    "US"
   }

--- a/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/US_Players/US_Markers.layer
+++ b/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/US_Players/US_Markers.layer
@@ -83,4 +83,18 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
   }
   m_bringToFront 0
  }
+ Blu_Mark_7 {
+  coords 6300.873 93.157 10901.926
+  angleY 90
+  m_sImageSet "{7CD99D22C7AE8195}UI/Textures/GroupManagement/FlagIcons/GroupFlagsOpfor.imageset"
+  m_sImageSetGlow ""
+  m_MarkerColor 0.561 0.071 0.071 1
+  m_sQuadName "infantry"
+  m_fWorldSize 80
+  m_sDescription "Infantry Platoon"
+  m_aVisibleForFactions {
+   "US"
+  }
+  m_bringToFront 0
+ }
 }

--- a/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/US_Players/US_Players.layer
+++ b/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/US_Players/US_Players.layer
@@ -6,7 +6,7 @@ $grp SCR_AIGroup : "{0B9DC54980B31D0F}Prefabs/Groups/BLUFOR/US/Army_1990_Rifles_
    }
    PS_GroupCallsignAssigner "{6568DE60D4D11520}" {
     m_iCompanyCallsign 1
-    m_iPlatoonCallsign 1
+    m_iPlatoonCallsign 2
     m_iSquadCallsign 1
    }
   }
@@ -29,7 +29,7 @@ $grp SCR_AIGroup : "{0B9DC54980B31D0F}Prefabs/Groups/BLUFOR/US/Army_1990_Rifles_
    }
    PS_GroupCallsignAssigner "{6568DE60D752F3C1}" {
     m_iCompanyCallsign 1
-    m_iPlatoonCallsign 1
+    m_iPlatoonCallsign 2
     m_iSquadCallsign 2
    }
   }
@@ -52,7 +52,7 @@ $grp SCR_AIGroup : "{0B9DC54980B31D0F}Prefabs/Groups/BLUFOR/US/Army_1990_Rifles_
    }
    PS_GroupCallsignAssigner "{6568DE60D287DFCE}" {
     m_iCompanyCallsign 1
-    m_iPlatoonCallsign 1
+    m_iPlatoonCallsign 2
     m_iSquadCallsign 3
    }
   }
@@ -75,7 +75,7 @@ $grp SCR_AIGroup : "{0B9DC54980B31D0F}Prefabs/Groups/BLUFOR/US/Army_1990_Rifles_
    }
    PS_GroupCallsignAssigner "{6568DE60DE63AA9C}" {
     m_iCompanyCallsign 1
-    m_iPlatoonCallsign 1
+    m_iPlatoonCallsign 2
     m_iSquadCallsign 4
    }
   }
@@ -98,7 +98,7 @@ $grp SCR_AIGroup : "{0B9DC54980B31D0F}Prefabs/Groups/BLUFOR/US/Army_1990_Rifles_
    }
    PS_GroupCallsignAssigner "{6568DE60CFE18379}" {
     m_iCompanyCallsign 2
-    m_iPlatoonCallsign 2
+    m_iPlatoonCallsign 3
     m_iSquadCallsign 1
    }
   }
@@ -107,7 +107,7 @@ $grp SCR_AIGroup : "{0B9DC54980B31D0F}Prefabs/Groups/BLUFOR/US/Army_1990_Rifles_
   angleY -96.662
   angleZ 0.187
   m_aUnitPrefabSlots {
-   "{6FD27881621A2747}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewCommander_PSG_P.et" "{B94C515ED8EA024E}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewGunner_P.et" "{6838AF507D6AAF2D}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewDriver_P.et"
+   "{FB3ECBB227CBEC38}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewCommander_P.et" "{B94C515ED8EA024E}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewGunner_P.et" "{6838AF507D6AAF2D}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewDriver_P.et"
   }
   m_sCustomNameSet "Bradley 3'1"
   m_aUnitPrefabColorTeams {
@@ -121,7 +121,7 @@ $grp SCR_AIGroup : "{0B9DC54980B31D0F}Prefabs/Groups/BLUFOR/US/Army_1990_Rifles_
    }
    PS_GroupCallsignAssigner "{6568DE60C9DF004E}" {
     m_iCompanyCallsign 2
-    m_iPlatoonCallsign 2
+    m_iPlatoonCallsign 3
     m_iSquadCallsign 2
    }
   }
@@ -130,7 +130,7 @@ $grp SCR_AIGroup : "{0B9DC54980B31D0F}Prefabs/Groups/BLUFOR/US/Army_1990_Rifles_
   angleY -40.032
   angleZ -0.451
   m_aUnitPrefabSlots {
-   "{6FD27881621A2747}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewCommander_PSG_P.et" "{B94C515ED8EA024E}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewGunner_P.et" "{6838AF507D6AAF2D}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewDriver_P.et"
+   "{FB3ECBB227CBEC38}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewCommander_P.et" "{B94C515ED8EA024E}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewGunner_P.et" "{6838AF507D6AAF2D}Prefabs/Characters/Factions/BLUFOR/US_Army/Character_US_CrewDriver_P.et"
   }
   m_sCustomNameSet "Bradley 3'2"
   m_aUnitPrefabColorTeams {
@@ -162,12 +162,13 @@ $grp Tank : "{72018C87FBDC9F8C}Prefabs/Vehicles/Tracked/BFV/M2A2_Desert.et" {
       SlotTemplate InventoryStorageSlot UGLammo {
        Prefab "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et"
       }
-      NumSlots 2
+      NumSlots 4
      }
      MultiSlotConfiguration "{6568DE6461C9F77D}" {
       SlotTemplate InventoryStorageSlot UGLammo {
        Prefab "{33CBDE73AB48172A}Prefabs/Weapons/Explosives/DemoBlock_M112/DemoBlock_M112.et"
       }
+      NumSlots 24
      }
     }
    }
@@ -198,12 +199,13 @@ $grp Tank : "{72018C87FBDC9F8C}Prefabs/Vehicles/Tracked/BFV/M2A2_Desert.et" {
       SlotTemplate InventoryStorageSlot UGLammo {
        Prefab "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et"
       }
-      NumSlots 2
+      NumSlots 4
      }
      MultiSlotConfiguration "{6568DE6408B4FDCE}" {
       SlotTemplate InventoryStorageSlot UGLammo {
        Prefab "{33CBDE73AB48172A}Prefabs/Weapons/Explosives/DemoBlock_M112/DemoBlock_M112.et"
       }
+      NumSlots 24
      }
     }
    }
@@ -222,7 +224,7 @@ SCR_AIGroup : "{B919E00642247722}Prefabs/Groups/BLUFOR/US/Army_1990_Rifles_Deser
   }
   PS_GroupCallsignAssigner "{6568DE60CC33B86C}" {
    m_iCompanyCallsign 1
-   m_iPlatoonCallsign 1
+   m_iPlatoonCallsign 2
   }
  }
  coords 5987.847 92.079 10330.896

--- a/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/default.layer
+++ b/worlds/HitTheMan/Battle For Rasman/BattleForRasman_Layers/default.layer
@@ -330,59 +330,32 @@ $grp PolylineShapeEntity : "{85222A2744768C81}Prefabs/Logic/AOLimit/TILW_AOLimit
    ShapePoint "{6566F0B8A0029610}" {
     Position -121.342 2.104 112.101
    }
-   ShapePoint "{6566F0B8A7E016D4}" {
-    Position -274.758 5.806 104.614
+   ShapePoint "{65717A5314A7CA48}" {
+    Position -215.579 4.545 105.522
    }
-   ShapePoint "{6566F0B958E72BDF}" {
-    Position -371.176 9.922 117.856
+   ShapePoint "{65717A531426CBF7}" {
+    Position -229.485 1.762 53.348
    }
-   ShapePoint "{6568DE5351D01A5D}" {
-    Position -485.161 19.951 29.382
+   ShapePoint "{65717A530B8C15A7}" {
+    Position -215.825 6.631 1.659
    }
-   ShapePoint "{6568DE7F9C4BDAEB}" {
-    Position -485.92 20.088 -18.271
+   ShapePoint "{65717A530A8BC813}" {
+    Position -191.027 7.032 -33.541
    }
-   ShapePoint "{6568DE7F93912BB2}" {
-    Position -464.802 11.258 -84.52
+   ShapePoint "{65717A530A0FBE6F}" {
+    Position -149.893 7.004 -80.372
    }
-   ShapePoint "{6568DE7F92DCBEAA}" {
-    Position -404.231 6.412 -149.177
+   ShapePoint "{65717A5309986111}" {
+    Position -155.627 7.032 -151.195
    }
-   ShapePoint "{6568DE7F918C9A64}" {
-    Position -380.903 7.032 -204.719
+   ShapePoint "{65717A530FBF6304}" {
+    Position -151.148 7.032 -213.623
    }
-   ShapePoint "{6568DE7F95F70DC1}" {
-    Position -371.282 7.031 -295.685
+   ShapePoint "{65717A530EE48977}" {
+    Position -111.893 7.032 -257.32
    }
-   ShapePoint "{6568DE7F952B71C2}" {
-    Position -377.847 7.032 -346.062
-   }
-   ShapePoint "{6568DE7F8BF1ACE1}" {
-    Position -369.828 7 -391.483
-   }
-   ShapePoint "{6568DE7F8F1A1DC1}" {
-    Position -311.771 7.032 -449.134
-   }
-   ShapePoint "{6568DE7F8E840DFA}" {
-    Position -241.917 4.485 -481.369
-   }
-   ShapePoint "{6568DE7F8DED90D2}" {
-    Position -219.917 6.425 -489.205
-   }
-   ShapePoint "{6566F0B96BB279D6}" {
-    Position -168.828 7.712 -458.613
-   }
-   ShapePoint "{6566F0B96A93B0DF}" {
-    Position -131.197 7.213 -429.351
-   }
-   ShapePoint "{6566F0B96A29200F}" {
-    Position -66.303 4.291 -376.98
-   }
-   ShapePoint "{6566F0B968E59515}" {
-    Position -17.057 3.946 -343.373
-   }
-   ShapePoint "{6566F0B963F70534}" {
-    Position -0.185 3.954 -323.842
+   ShapePoint "{65717A530D4C9D8B}" {
+    Position -46.796 3.548 -282.408
    }
    ShapePoint "{6566F0B9631F8DF2}" {
     Position 14.515 2.618 -284.997
@@ -522,6 +495,7 @@ TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramewor
    }
   }
   TILW_MissionEvent "{6568DE655C51C38C}" {
+   m_name "US Obj Victory"
    m_instructions {
     TILW_SendMessageInstruction "{6568DE6524F79094}" {
      m_executionDelay 10
@@ -546,17 +520,76 @@ TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramewor
     }
    }
   }
+  TILW_MissionEvent "{65717A518D8C24A1}" {
+   m_name "Civis Move"
+   m_instructions {
+    TILW_AssignWaypointsInstruction "{65717A51B9C76722}" {
+     m_executionDelay 1
+     m_groupName "Civ_1"
+     m_waypointNames {
+      "Civ_Move"
+     }
+     m_clearExisting 1
+    }
+    TILW_AssignWaypointsInstruction "{65717A504E7A4197}" {
+     m_executionDelay 1
+     m_groupName "Civ_2"
+     m_waypointNames {
+      "Civ_Move"
+     }
+     m_clearExisting 1
+    }
+    TILW_AssignWaypointsInstruction "{65717A5041BC0BFF}" {
+     m_executionDelay 1
+     m_groupName "Civ_3"
+     m_waypointNames {
+      "Civ_Move"
+     }
+     m_clearExisting 1
+    }
+    TILW_AssignWaypointsInstruction "{65717A5046214614}" {
+     m_executionDelay 1
+     m_groupName "Civ_4"
+     m_waypointNames {
+      "Civ_Move"
+     }
+     m_clearExisting 1
+    }
+    TILW_AssignWaypointsInstruction "{65717A507B40270B}" {
+     m_executionDelay 1
+     m_groupName "Civ_5"
+     m_waypointNames {
+      "Civ_Move"
+     }
+     m_clearExisting 1
+    }
+    TILW_AssignWaypointsInstruction "{65717A5078F1C225}" {
+     m_executionDelay 1
+     m_groupName "Civ_6"
+     m_waypointNames {
+      "Civ_Move"
+     }
+     m_clearExisting 1
+    }
+    TILW_SendMessageInstruction "{65717A5F42561067}" {
+     m_messageTitle "test message ladida"
+    }
+   }
+   m_condition TILW_LiteralTerm "{65717A51A3DE4390}" {
+    m_flagName "SWCompound"
+   }
+  }
  }
  m_casualtyFlags {
   TILW_FactionPlayersKilledFlag "{6506E4081586428B}" {
    m_flagName "TKA_CAS"
    m_factionKey "GC_TKA"
-   m_casualtyRatio 0.9
+   m_casualtyRatio 0.95
   }
   TILW_FactionPlayersKilledFlag "{6568DE7681798812}" {
    m_flagName "US_CAS"
    m_factionKey "US"
-   m_casualtyRatio 0.9
+   m_casualtyRatio 0.8
   }
  }
 }


### PR DESCRIPTION
- Defenders gets pre-placed minefields (A lot of them), only 2 are known to BLUFOR Due to the security platoon to their north
- 3x UAZs instead of a Ural (2x Unarmed, 1x UK59 Gun)
- 36x AT Mines total (12x each)
- Smaller AO to focus on the town itself
- AI Squad(s) south of Rasman
- Relocated some of the BMPs

- Attackers gets more Clackers & Demos (4x Clack, 24x Demos per Bradley, 8x and 48x Total)
- Fixed Comsig
- Fixed Bradley Commander character

- New Casualty Limits for both sides