### PR TITLE
(UPDATE) TVT (51-68) Iron Resolve v1.3

### DIFF
--- a/Missions/Gabe/IronResolve/IronResolve.conf
+++ b/Missions/Gabe/IronResolve/IronResolve.conf
@@ -1,7 +1,7 @@
 SCR_MissionHeader {
  World "{9AF99979E3CE957D}worlds/Gabe/IronResolve/IronResolve.ent"
- m_sName "TVT (54-74) Iron Resolve"
+ m_sName "TVT (51-68) Iron Resolve"
  m_sAuthor "Gabe"
  m_sDescription "US Army platoon assaults Iraqi city held by insurgents with support of HMMWVs and Strykers."
- m_iPlayerCount 74
+ m_iPlayerCount 68
 }

--- a/worlds/Gabe/IronResolve/IronResolve_Layers/Briefing.layer
+++ b/worlds/Gabe/IronResolve/IronResolve_Layers/Briefing.layer
@@ -29,7 +29,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "<b><u>Enemy composition includes:</b></u>"\
   ""\
   " - Enemy HQ Section coordinating defensive operations."\
-  " - Up to 5x insurgent cells (light infantry) equipped with small arms and technical knowledge of urban warfare."\
+  " - Up to 4x insurgent cells (light infantry) equipped with small arms and technical knowledge of urban warfare."\
   " - One RPG team capable of engaging armored vehicles and fortified positions."\
   " - Possible explosives experts ready to employ IEDs."\
   ""\
@@ -168,8 +168,8 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTextData "Following the collapse of the Iraqi Army and central government authority, local resistance fighters have seized control of the city and established defensive positions to repel foreign forces."\
   ""\
   "Friendly Forces Composition:"\
-  " - Command section with medics, 2IC, and sappers"\
-  " - Up to 5x cells comprised of up to 4 men each"\
+  " - Command section with sappers and a medic"\
+  " - Up to 4x cells comprised of up to 4 men each"\
   " - RPG Team to use against enemy infantry and vehicles"\
   " - 6x cars for the cells and 1x van for HQ"
   m_aVisibleForFactions {
@@ -219,7 +219,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
  ALL_IMPORTANTNOTES {
   coords 5552.244 25.144 3124.629
   m_sTitle "HMMWV Rules"
-  m_sTextData "RTO has radio backpack with more range. Each Stryker has a backpack radio in the inventory so that the Stryker commanders can communicate with the RTO if further than 500m away."\
+  m_sTextData "For US: RTO has radio backpack with more range to help communicate with Stryker crews (who also have radio backpacks). Otherwise, your radio is ~500m range."\
   ""\
   "US may only take 1 armed M2 HMMWV per squad (HQ section gets unarmed HMMWV). If mission is played at or close to minimum, this would mean that US would take only 3 of the 4 armed HMMWV's. GMs use best judgement."\
   ""

--- a/worlds/Gabe/IronResolve/IronResolve_Layers/Briefing.layer
+++ b/worlds/Gabe/IronResolve/IronResolve_Layers/Briefing.layer
@@ -221,7 +221,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTitle "HMMWV Rules"
   m_sTextData "For US: RTO has radio backpack with more range to help communicate with Stryker crews (who also have radio backpacks). Otherwise, your radio is ~500m range."\
   ""\
-  "US may only take 1 armed M2 HMMWV per squad (HQ section gets unarmed HMMWV). If mission is played at or close to minimum, this would mean that US would take only 3 of the 4 armed HMMWV's. GMs use best judgement."\
+  "US may only take 1 armed M2 HMMWV per squad (HQ section gets unarmed HMMWV). If mission is played at or close to minimum, this would mean that US would take only 3 of the 4 armed HMMWV's. Mission maker suggestion: If ratio results in US Army getting 38 players or more, they can take 4x M2 HMMWV's, if less than 38 players, they only take 3. GMs use best judgement."\
   ""
   m_aVisibleForFactions {
    "US"

--- a/worlds/Gabe/IronResolve/IronResolve_Layers/Players_Blufor.layer
+++ b/worlds/Gabe/IronResolve/IronResolve_Layers/Players_Blufor.layer
@@ -22,14 +22,14 @@ $grp SCR_AIGroup : "{9FF025AC10641CFE}Prefabs/Groups/BLUFOR/US/Army/2003/Infantr
     Enabled 1
     m_iCompanyCallsign 1
     m_iPlatoonCallsign 1
-    m_iSquadCallsign 5
+    m_iSquadCallsign 7
    }
   }
   coords 4670.317 17.844 4675.853
   angles 0 -40.617 0
   m_aUnitPrefabSlots {
-   "{24A4AD4C57301A31}Prefabs/Characters/Factions/BLUFOR/US_Army/1998/Infantry (Desert)/P/Character_US_CrewCommander_DCU_1998_P.et"
-   "{152488484C3EF010}Prefabs/Characters/Factions/BLUFOR/US_Army/1998/Infantry (Desert)/P/Character_US_CrewDriver_DCU_1998_P.et"
+   "{3D83A5A0EC9F7416}Prefabs/Characters/Factions/BLUFOR/US_Army/2003/Infantry (Desert)/P/Character_US_2003_D_CrewCommander_P.et"
+   "{8735575F8B41A7DD}Prefabs/Characters/Factions/BLUFOR/US_Army/2003/Infantry (Desert)/P/Character_US_2003_D_CrewDriver_P.et"
   }
   m_sCustomNameSet "Stryker Crew"
  }
@@ -42,14 +42,14 @@ $grp SCR_AIGroup : "{9FF025AC10641CFE}Prefabs/Groups/BLUFOR/US/Army/2003/Infantr
     Enabled 1
     m_iCompanyCallsign 1
     m_iPlatoonCallsign 1
-    m_iSquadCallsign 6
+    m_iSquadCallsign 8
    }
   }
   coords 4661.821 17.844 4667.447
   angles 0 -41.748 0
   m_aUnitPrefabSlots {
-   "{24A4AD4C57301A31}Prefabs/Characters/Factions/BLUFOR/US_Army/1998/Infantry (Desert)/P/Character_US_CrewCommander_DCU_1998_P.et"
-   "{152488484C3EF010}Prefabs/Characters/Factions/BLUFOR/US_Army/1998/Infantry (Desert)/P/Character_US_CrewDriver_DCU_1998_P.et"
+   "{3D83A5A0EC9F7416}Prefabs/Characters/Factions/BLUFOR/US_Army/2003/Infantry (Desert)/P/Character_US_2003_D_CrewCommander_P.et"
+   "{8735575F8B41A7DD}Prefabs/Characters/Factions/BLUFOR/US_Army/2003/Infantry (Desert)/P/Character_US_2003_D_CrewDriver_P.et"
   }
   m_sCustomNameSet "Stryker Crew"
  }

--- a/worlds/Gabe/IronResolve/IronResolve_Layers/Players_Opfor.layer
+++ b/worlds/Gabe/IronResolve/IronResolve_Layers/Players_Opfor.layer
@@ -35,7 +35,7 @@ $grp SCR_AIGroup : "{80BDE40EE0ADF9E3}Prefabs/Groups/OPFOR/GC_INSURGENT/P/GC_INS
     Enabled 0
    }
    PS_GroupCallsignAssigner "{63616C6C7369676E}" {
-    Enabled 1,
+    Enabled 1
     m_iSquadCallsign 1
    }
   }
@@ -130,26 +130,6 @@ $grp SCR_AIGroup : "{80BDE40EE0ADF9E3}Prefabs/Groups/OPFOR/GC_INSURGENT/P/GC_INS
   }
   m_sCustomNameSet "Al Hadra Rebels"
  }
- Cell5 {
-  components {
-   AIFormationComponent "{507E9DC12F541FE6}" {
-    Enabled 0
-   }
-   PS_GroupCallsignAssigner "{63616C6C7369676E}" {
-    Enabled 1
-    m_iSquadCallsign 5
-   }
-  }
-  coords 6601.862 17.844 3012.964
-  angles 0 -177.628 0
-  m_aUnitPrefabSlots {
-   "{8571D23E67D8DA03}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/P/Character_GC_INSURGENT_SL_P.et"
-   "{B599A1329E64DBF0}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/P/Character_GC_INSURGENT_MG_P.et"
-   "{9D243834CC857277}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/P/Character_GC_INSURGENT_AT_P.et"
-   "{27218EAB079881EA}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/P/Character_GC_INSURGENT_Rifleman_P.et"
-  }
-  m_sCustomNameSet "Al Hadra Rebels"
- }
 }
 SCR_AIGroup CellHQ : "{B7430DCCC8D6FA05}Prefabs/Groups/OPFOR/GC_INSURGENT/P/GC_INSURGENT_PHQ_P.et" {
  components {
@@ -164,10 +144,8 @@ SCR_AIGroup CellHQ : "{B7430DCCC8D6FA05}Prefabs/Groups/OPFOR/GC_INSURGENT/P/GC_I
  angles 0 -178.37 0
  m_aUnitPrefabSlots {
   "{8571D23E67D8DA03}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/P/Character_GC_INSURGENT_SL_P.et"
-  "{57F7E238FEAF7E01}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/P/Character_GC_INSURGENT_TL_P.et"
   "{0CC224E1B6C2AD9E}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/P/Character_GC_INSURGENT_Sapper_P.et"
   "{0CC224E1B6C2AD9E}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/P/Character_GC_INSURGENT_Sapper_P.et"
-  "{040BCEE9A8091FEB}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/P/Character_GC_INSURGENT_Medic_P.et"
   "{040BCEE9A8091FEB}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/P/Character_GC_INSURGENT_Medic_P.et"
  }
  m_sCustomNameSet "Al Hadra HQ"

--- a/worlds/Gabe/IronResolve/IronResolve_Layers/Vehicles_Blufor.layer
+++ b/worlds/Gabe/IronResolve/IronResolve_Layers/Vehicles_Blufor.layer
@@ -27,6 +27,7 @@ $grp Vehicle : "{65A1EB5BC8449FD3}Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/S
     MultiSlots {
      MultiSlotConfiguration "{5EAD79DA34C929EB}" {
       SlotTemplate LoadoutSlotInfo MA {
+       Enabled 0
        Prefab "{78AD6277BCA654C4}Prefabs/Items/Equipment/Radios/US/Radio_M81_GC_PRC119.et"
       }
       NumSlots 1
@@ -44,6 +45,7 @@ $grp Vehicle : "{65A1EB5BC8449FD3}Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/S
     MultiSlots {
      MultiSlotConfiguration "{5EAD79DA34C929EB}" {
       SlotTemplate LoadoutSlotInfo MA {
+       Enabled 0
        Prefab "{78AD6277BCA654C4}Prefabs/Items/Equipment/Radios/US/Radio_M81_GC_PRC119.et"
       }
       NumSlots 1

--- a/worlds/Gabe/IronResolve/IronResolve_Layers/default.layer
+++ b/worlds/Gabe/IronResolve/IronResolve_Layers/default.layer
@@ -88,6 +88,9 @@ PS_GameModeCoop GameModeLobby : "{4CFD54745CD45673}Prefabs/MP/Modes/PS_GameMode_
        SCR_CallsignInfo "{55CCB792D0C8B3CE}" {
         m_sCallsign "3"
        }
+       SCR_CallsignInfo "{64E2F896A8E698B6}" {
+        m_sCallsign ""
+       }
        SCR_CallsignInfo "{685E078F2F05FC93}" {
         m_sCallsign "4"
        }


### PR DESCRIPTION
- removed 5th cell from Insurgents as well as 2ic and 1 of the medic slots for ratio reasons, cell 1 leader will act as 2ic
- changed vehcrew to 2003 vehcrew prefabs
- removed extra backpack radios from strykers
- adjuted briefing/config file to reflect changes

- [X] Briefing, map, slotting screen
- [X] Setup timers / AO Limits
- [X] Custom prefabs
- [X] Key framework events and interactions (QRFs, etc)
- [X] End conditions
- [ ] Playable in Dedicated Server Tool / Peer Tool
