### PR TITLE
Swap helicopters, add AH1Z/UH1Y vehicles

### DIFF
--- a/worlds/Jub/CobrasBite/Cobras_bite_Layers/default.layer
+++ b/worlds/Jub/CobrasBite/Cobras_bite_Layers/default.layer
@@ -55,8 +55,9 @@ PolylineShapeEntity : "{85222A2744768C81}Prefabs/Logic/AOLimit/TILW_AOLimit.et" 
     "RHS_USAF"
    }
    m_ignoredVehicles {
-    "{7981D5EB0583B2B3}Prefabs/Vehicles/Helicopters/AH1S/AH1S_Marines_XM65.et"
-    "{B67D806064FA55C6}Prefabs/Vehicles/Helicopters/UH1H/UH1H_armed_gunship_x14APKWS_sharkNose_m2_m134.et"
+    "{124BF96EFF7BDEB0}Prefabs/Vehicles/Helicopters/UH1H/AH1Z_LAU61_(x78).et"
+    "{10340BBEDA1F26E8}Prefabs/Vehicles/Helicopters/UH1H/AH1Z_M299_(x16).et"
+    "{6F57BF4E759DF6DF}Prefabs/Vehicles/Helicopters/UH1H/UH1Y_Armed_Gunship_Sage.et"
    }
   }
   TILW_MapShapeComponent "{6508F54F9B461198}" {

--- a/worlds/Jub/CobrasBite/Cobras_bite_Layers/players.layer
+++ b/worlds/Jub/CobrasBite/Cobras_bite_Layers/players.layer
@@ -1,3 +1,13 @@
+Vehicle AH1Z_M299__x16_2 : "{10340BBEDA1F26E8}Prefabs/Vehicles/Helicopters/UH1H/AH1Z_M299_(x16).et" {
+ coords 3704.186 17.844 7871.804
+ angles 0 -169.18 0
+ m_sAttachmentGroupName "ACE"
+}
+Vehicle AH1Z_LAU61__x78_1 : "{124BF96EFF7BDEB0}Prefabs/Vehicles/Helicopters/UH1H/AH1Z_LAU61_(x78).et" {
+ coords 3670.066 17.844 7868.002
+ angles 0 159.939 0
+ m_sAttachmentGroupName "ACE"
+}
 $grp SCR_AIGroup : "{17DA43E650D13074}Prefabs/Groups/BLUFOR/US/Marines/2025/Marine Rifles/Desert/Group_USMC_2025_RiflePHQ_D.et" {
  PHQ {
   components {
@@ -119,32 +129,30 @@ $grp SCR_AIGroup : "{3542DA9833C9BA69}Prefabs/Groups/BLUFOR/US/Marines/2025/Mari
   }
  }
 }
-$grp Vehicle : "{7981D5EB0583B2B3}Prefabs/Vehicles/Helicopters/AH1S/AH1S_Marines_XM65.et" {
- AH1S_Marines_XM1 {
-  coords 3698.937 17.844 7860.269
-  angles 0 -160.963 0
-  m_sAttachmentGroupName "ACE"
- }
- AH1S_Marines_XM2 {
-  coords 3674.01 17.844 7859.625
-  angles 0 149.927 0
-  m_sAttachmentGroupName "ACE"
- }
+Vehicle UH1Y_Armed_Gunship_Sage1 : "{6F57BF4E759DF6DF}Prefabs/Vehicles/Helicopters/UH1H/UH1Y_Armed_Gunship_Sage.et" {
+ coords 3688.837 17.844 7879.566
+ angles 0 178.503 0
+ m_sAttachmentGroupName "ACE"
 }
 Vehicle JLTV_Base_CobrasBite1 : "{86157A4F8B90F06F}worlds/Jub/CobrasBite/Prefabs/JLTV_Base_CobrasBite.et" {
  coords 3938.26 17.844 1674.986
  angles 0 168.25 0
  m_sAttachmentGroupName "CAAT"
 }
-Vehicle UH1H_armed_gunship_x14APKWS_sharkNose_m2_m1 : "{B67D806064FA55C6}Prefabs/Vehicles/Helicopters/UH1H/UH1H_armed_gunship_x14APKWS_sharkNose_m2_m134.et" {
- coords 3686.04 17.844 7876.875
- angles 0 -178.163 0
- m_sAttachmentGroupName "ACE"
-}
 SCR_AIGroup Sq2 : "{C62B0A55626A9D90}Prefabs/Groups/BLUFOR/US/Marines/2025/Marine Rifles/Desert/Group_USMC_2025_RifleSquad_MAAW_D.et" {
  components {
   PS_GroupCallsignAssigner "{63616C6C7369676E}" {
    Enabled 1
+  }
+  SCR_EditableGroupComponent "{50D291F6C83FA532}" {
+   m_UIInfo SCR_EditableGroupUIInfo "{5298E609432D192D}" {
+    Name "2025 USMC Rifle Squad"
+    m_aAuthoredLabels +{
+    }
+    m_MilitarySymbol SCR_MilitarySymbol "{563682D06ED5ACD9}" {
+     m_Icons 1048577
+    }
+   }
   }
  }
  coords 3952.368 17.843 1635.692


### PR DESCRIPTION
# Overview

Replace legacy AH1S/UH1H helicopter references with newer AH1Z and UH1Y variants and update scene spawns. default.layer: removed two ignored UH1H/AH1S entries and added AH1Z_LAU61, AH1Z_M299 and UH1Y_Armed_Gunship_Sage to m_ignoredVehicles. players.layer: added Vehicle entities for AH1Z_M299 and AH1Z_LAU61, removed the old AH1S/UH1H spawns and added a UH1Y_Armed_Gunship_Sage spawn; also added an SCR_EditableGroupComponent (UI info) to the Sq2 group. These changes update which helicopter prefabs are used and expose the squad as editable in the editor.


## Testing
If you have not already, please read [testing your mission](https://github.com/Global-Conflicts-ArmA/gc-reforger-missions/wiki/Testing-your-mission).

Have you tested the following are all working as intended?
- [ ] Briefing, map, slotting screen
- [ ] Setup timers / AO Limits
- [ ] Custom prefabs
- [ ] Key framework events and interactions (QRFs, etc)
- [ ] End conditions
- [ ] Playable in Dedicated Server Tool / Peer Tool

## Comments for the reviewer
Put any specifics the mission reviewer needs to look out for or double check here.

## Dependencies

**_https://github.com/Global-Conflicts-ArmA/gc-reforger-core/pull/46_**

