### PR TITLE
Relocate Taliban SP and disable teleporter

### DIFF
--- a/worlds/Jub/OperationJaws/OperationJaws_Layers/Teleportestuff.layer
+++ b/worlds/Jub/OperationJaws/OperationJaws_Layers/Teleportestuff.layer
@@ -22,6 +22,7 @@ GenericEntity : "{14B2D417839BF8A3}PrefabsEditable/Auto/Structures/Military/Flag
 GenericEntity : "{5B462DF843A26368}Prefabs/Utils/Interactions/TILW_TeleportInteraction.et" {
  components {
   ActionsManagerComponent "{62EF76E0D47ED96A}" {
+   Enabled 0
    additionalActions {
     TILW_TeleportInteraction "{62EF76E608B6CB36}" {
      ActionTitle "Teleport -> Insert 1 (ONE)"
@@ -69,6 +70,12 @@ GenericEntity : "{5B462DF843A26368}Prefabs/Utils/Interactions/TILW_TeleportInter
      }
     }
    }
+  }
+  RplComponent "{62EF76E0D47ED97D}" {
+   Enabled 0
+  }
+  Hierarchy "{62EF76E0D47ED97F}" {
+   Enabled 0
   }
  }
  coords 2724.678 146.715 8686.552

--- a/worlds/Jub/OperationJaws/OperationJaws_Layers/briefing.layer
+++ b/worlds/Jub/OperationJaws/OperationJaws_Layers/briefing.layer
@@ -39,7 +39,7 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
   m_bShowForAnyFaction 1
  }
  RU_Marker {
-  coords 2725.84 144.219 8691.187
+  coords 4516.614 143.5 8121.791
   angles 0 90 0
   m_sImageSet "{7CD99D22C7AE8195}UI/Textures/GroupManagement/FlagIcons/GroupFlagsOpfor.imageset"
   m_sImageSetGlow ""
@@ -59,5 +59,17 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
   m_sDescription "Tanks"
   m_bVisibleForEmptyFaction 1
   m_bShowForAnyFaction 1
+ }
+ RU_Marker2 {
+  coords 2726.534 145.171 8688.442
+  angles 0 90 0
+  m_sImageSet "{7CD99D22C7AE8195}UI/Textures/GroupManagement/FlagIcons/GroupFlagsOpfor.imageset"
+  m_sImageSetGlow ""
+  m_sQuadName "infantry"
+  m_fWorldSize 180
+  m_sDescription "Taliban RP"
+  m_aVisibleForFactions {
+   "GC_INSURGENT"
+  }
  }
 }

--- a/worlds/Jub/OperationJaws/OperationJaws_Layers/briefing_TB.layer
+++ b/worlds/Jub/OperationJaws/OperationJaws_Layers/briefing_TB.layer
@@ -37,11 +37,9 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTitle "II. Friendly Forces"
   m_sTextData "Platoon strength Taliban fighters located at our marked SP"\
   ""\
-  "We have x30 more respawns and respawn at the SP."\
+  "We have x30 respawns and respawn at the RP."\
   ""\
-  "There is a teleporter flagpole that will allow us to move closer to the FLET if needed. Feel free to TP behind US players after they cap a zone. "\
-  ""\
-  "We also have vehicles:"\
+  "We have vehicles located at our RP:"\
   ""\
   "We have x13 motorbikes, x5 VBIEDs, x3 transport landrovers, x1 M2HB m151 jeep, x3 GPMG landrovers, x1 PKM UAZ"
   m_aVisibleForFactions {

--- a/worlds/Jub/OperationJaws/OperationJaws_Layers/default.layer
+++ b/worlds/Jub/OperationJaws/OperationJaws_Layers/default.layer
@@ -56,6 +56,7 @@ PS_GameModeCoop PS_GameMode_Lobby_GC1 : "{4CFD54745CD45673}Prefabs/MP/Modes/PS_G
   PS_FactionRespawnCount "{6931676F4332C17C}" {
    m_sFactionKey "GC_INSURGENT"
    m_iCount 30
+   m_sPosition "RU_Marker2"
   }
  }
  {

--- a/worlds/Jub/OperationJaws/OperationJaws_Layers/players_Taliban.layer
+++ b/worlds/Jub/OperationJaws/OperationJaws_Layers/players_Taliban.layer
@@ -4,7 +4,7 @@ SCR_AIGroup : "{95865B5D03AFBA74}Prefabs/Groups/OPFOR/GC_INSURGENT/Afghan Insurg
    DefaultFormation "line"
   }
  }
- coords 2714.735 145.124 8688.148
+ coords 4513.514 143.5 8122.93
  m_aUnitPrefabSlots +{
   "{656C3D2563E79F50}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/Afghan Insurgents/Character_GC_INS_Afghan_Sapper.et"
   "{656C3D2563E79F50}Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/Afghan Insurgents/Character_GC_INS_Afghan_Sapper.et"
@@ -12,7 +12,6 @@ SCR_AIGroup : "{95865B5D03AFBA74}Prefabs/Groups/OPFOR/GC_INSURGENT/Afghan Insurg
  }
  m_bPlayable 1
  m_bSetPlayable 1
- m_vRespawnPosition 2709.716 144.219 8665.849
 }
 $grp SCR_AIGroup : "{AD6A6865CC0F4D68}Prefabs/Groups/OPFOR/GC_INSURGENT/Afghan Insurgents/GC_INS_Afghan_Squad.et" {
  {
@@ -21,10 +20,9 @@ $grp SCR_AIGroup : "{AD6A6865CC0F4D68}Prefabs/Groups/OPFOR/GC_INSURGENT/Afghan I
     DefaultFormation "line"
    }
   }
-  coords 2714.26 144.352 8690.238
+  coords 4513.687 143.5 8121.602
   m_bPlayable 1
   m_bSetPlayable 1
-  m_vRespawnPosition 2709.716 144.219 8665.849
  }
  {
   components {
@@ -32,10 +30,9 @@ $grp SCR_AIGroup : "{AD6A6865CC0F4D68}Prefabs/Groups/OPFOR/GC_INSURGENT/Afghan I
     DefaultFormation "line"
    }
   }
-  coords 2714.301 144.519 8692.333
+  coords 4513.882 143.5 8120.386
   m_bPlayable 1
   m_bSetPlayable 1
-  m_vRespawnPosition 2709.716 144.219 8665.849
  }
  {
   components {
@@ -43,9 +40,8 @@ $grp SCR_AIGroup : "{AD6A6865CC0F4D68}Prefabs/Groups/OPFOR/GC_INSURGENT/Afghan I
     DefaultFormation "line"
    }
   }
-  coords 2714.159 144.771 8694.452
+  coords 4514.034 143.486 8119.093
   m_bPlayable 1
   m_bSetPlayable 1
-  m_vRespawnPosition 2709.716 144.219 8665.849
  }
 }

--- a/worlds/Jub/OperationJaws/OperationJaws_Layers/players_usmc.layer
+++ b/worlds/Jub/OperationJaws/OperationJaws_Layers/players_usmc.layer
@@ -25,11 +25,11 @@ $grp SCR_AIGroup : "{6574C561CBC719CF}Prefabs/Groups/BLUFOR/US/Marines/2009/Mari
   angles 0 -105.401 0
   m_aUnitPrefabSlots {
    "{A79C33B3A933A2E9}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/2025/Marines/Desert/Character_2025_USMC_CrewCO_D.et"
-   "{180E58FB284B70FC}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/2025/Marines/Desert/Character_2025_USMC_Crew_D.et"
-   "{180E58FB284B70FC}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/2025/Marines/Desert/Character_2025_USMC_Crew_D.et"
+   "{E9050156C3B0C34C}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/2025/Marines/Desert/Character_2025_USMC_CrewGunner_D.et"
+   "{180E58FB284B70FC}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/2025/Marines/Desert/Character_2025_USMC_CrewDriver_D.et"
    "{A79C33B3A933A2E9}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/2025/Marines/Desert/Character_2025_USMC_CrewCO_D.et"
-   "{180E58FB284B70FC}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/2025/Marines/Desert/Character_2025_USMC_Crew_D.et"
-   "{180E58FB284B70FC}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/2025/Marines/Desert/Character_2025_USMC_Crew_D.et"
+   "{E9050156C3B0C34C}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/2025/Marines/Desert/Character_2025_USMC_CrewGunner_D.et"
+   "{180E58FB284B70FC}Prefabs/Characters/Factions/BLUFOR/RHS_USAF/2025/Marines/Desert/Character_2025_USMC_CrewDriver_D.et"
   }
   m_bPlayable 1
   m_sCustomNameSet "Tank Section"


### PR DESCRIPTION
# Overview
Move Taliban player groups and RU marker to new RP coordinates, add RU_Marker2 at the original location and set insurgent respawn position to that marker. Disable the teleport interaction and related RplComponent/Hierarchy in Teleportestuff.layer. Remove hardcoded m_vRespawnPosition entries from players_Taliban groups and update their coords. Adjust briefing text to reference the RP and reword vehicle/teleporter lines.

## Testing
If you have not already, please read [testing your mission](https://github.com/Global-Conflicts-ArmA/gc-reforger-missions/wiki/Testing-your-mission).

Have you tested the following are all working as intended?
- [x] Briefing, map, slotting screen
- [x] Setup timers / AO Limits
- [x] Custom prefabs
- [x] Key framework events and interactions (QRFs, etc)
- [ ] End conditions
- [x] Playable in Dedicated Server Tool / Peer Tool

## Comments for the reviewer
Put any specifics the mission reviewer needs to look out for or double check here.

## Dependencies
***************************NOTICE MEE************************
https://github.com/Global-Conflicts-ArmA/gc-reforger-units/pull/284