### PR TITLE
BritsAtBearegard update: Swaped in BRDMs + other

### DIFF
--- a/Missions/RedTheKnown/BritsAtBeauregard.conf
+++ b/Missions/RedTheKnown/BritsAtBeauregard.conf
@@ -1,9 +1,9 @@
 SCR_MissionHeader {
  World "{C980DF310284853D}worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard.ent"
- m_sName "TVT (70-101) Brits at Beauregard"
+ m_sName "TVT (70-105) Brits at Beauregard"
  m_sAuthor "RedTheKnown"
  m_sDescription "British motorized force conducts an early morning assault against a recently landed Russian naval infantry force awaiting reinforcement. Year:1995"
  m_sGameMode "TVT"
- m_iPlayerCount 101
+ m_iPlayerCount 105
  m_iStartingHours 4
 }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Blufor/blufor_setuparea.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Blufor/blufor_setuparea.layer
@@ -8,8 +8,8 @@ $grp GameEntity : "{0E94F28FD722B1D8}Prefabs/Props/Military/Generators/Generator
     Enabled 0
    }
   }
-  coords 2702.68 77.48 1664.192
-  angles 0 147.214 0
+  coords 2603.864 60.396 1584.623
+  angles 0 151.215 0
  }
  {
   components {
@@ -20,8 +20,8 @@ $grp GameEntity : "{0E94F28FD722B1D8}Prefabs/Props/Military/Generators/Generator
     Enabled 0
    }
   }
-  coords 2727.527 77.476 1618.875
-  angles 0 -44.308 0
+  coords 2617.111 57.834 1556.038
+  angles 0 -25.145 0
  }
  {
   components {
@@ -32,8 +32,8 @@ $grp GameEntity : "{0E94F28FD722B1D8}Prefabs/Props/Military/Generators/Generator
     Enabled 0
    }
   }
-  coords 2724.653 77.531 1651.775
-  angles 0 -135.09 0
+  coords 2610.823 61.499 1590.143
+  angles 0 58.754 0
  }
  {
   components {
@@ -44,8 +44,44 @@ $grp GameEntity : "{0E94F28FD722B1D8}Prefabs/Props/Military/Generators/Generator
     Enabled 0
    }
   }
-  coords 2738.865 77.469 1628.482
-  angles 0 -47.748 0
+  coords 2627.827 59.3 1561.282
+  angles 0 48.789 0
+ }
+ {
+  components {
+   SCR_BaseInteractiveLightComponent "{587E9C1D47ACAF0D}" {
+    m_eInitialLightState LIT
+   }
+   ActionsManagerComponent "{5882888ADFDF5245}" {
+    Enabled 0
+   }
+  }
+  coords 2642.128 59.698 1549.18
+  angles 0 12.751 0
+ }
+ {
+  components {
+   SCR_BaseInteractiveLightComponent "{587E9C1D47ACAF0D}" {
+    m_eInitialLightState LIT
+   }
+   ActionsManagerComponent "{5882888ADFDF5245}" {
+    Enabled 0
+   }
+  }
+  coords 2606.487 63.393 1603.366
+  angles 0 96.371 0
+ }
+ {
+  components {
+   SCR_BaseInteractiveLightComponent "{587E9C1D47ACAF0D}" {
+    m_eInitialLightState LIT
+   }
+   ActionsManagerComponent "{5882888ADFDF5245}" {
+    Enabled 0
+   }
+  }
+  coords 2610.618 58.412 1568.811
+  angles 0 58.169 0
  }
 }
 GenericEntity : "{6018EBB342F59401}PrefabsEditable/Auto/Props/Military/AmmoBoxes/EquipmentBoxStack/E_EquipmentBoxStack_US_01_V4_covered.et" {
@@ -105,15 +141,24 @@ GenericEntity : "{6018EBB342F59401}PrefabsEditable/Auto/Props/Military/AmmoBoxes
    }
   }
  }
- coords 2711.316 77.494 1654.374
- angles 0 48.186 0
+ coords 2622.142 60.126 1576.634
+ angles 0 58.947 0
 }
 GenericEntity : "{A80E80B60FEAE52D}PrefabsEditable/Auto/Structures/Military/Flags/E_FlagPole_02_V1_UK.et" {
- coords 2711.815 77.531 1654.982
- angles 0 42.487 0
+ coords 2622.746 60.37 1577.138
+ angles 0 53.248 0
 }
-SCR_EditorRestrictionZoneEntity : "{B2A519402E9AC209}PrefabsEditable/RestrictionZone/E_EditorRestrictionZoneLarge.et" {
- coords 2688.652 75.06 1638.769
- m_fWarnRadius 80
- m_fZoneRadius 100
+$grp SCR_EditorRestrictionZoneEntity : "{B2A519402E9AC209}PrefabsEditable/RestrictionZone/E_EditorRestrictionZoneLarge.et" {
+ {
+  coords 2638.12 64.246 1590.051
+  m_fWarnRadius 80
+  m_fZoneRadius 90
+  m_fZoneTeleportedRadius 100
+ }
+ {
+  coords 2465.6 89.222 1412.451
+  m_fWarnRadius 55
+  m_fZoneRadius 70
+  m_fZoneTeleportedRadius 80
+ }
 }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Blufor/mortar.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Blufor/mortar.layer
@@ -7,21 +7,21 @@ GameEntity : "{0E94F28FD722B1D8}Prefabs/Props/Military/Generators/GeneratorFlood
    Enabled 0
   }
  }
- coords 2634.519 71.195 1635.312
- angles 0 -35.659 0
+ coords 2474.828 88.126 1410.18
+ angles 0 -58.076 0
 }
 GenericEntity : "{192A4FF528CB9DD0}Prefabs/Structures/Military/Camps/Foundations/Foundation_TentUS_01.et" {
- coords 2628.965 72.624 1645.08
- angles 0 -38.325 0
+ coords 2465.968 89.682 1417.091
+ angles 0 -60.742 0
 }
 $grp Turret : "{8094D99689ABE241}Prefabs/Weapons/Mortars/M252/Mortar_M252.et" {
  {
-  coords 2627.679 72.613 1647.659
-  angles 0 51.822 0
+  coords 2463.796 89.671 1418.985
+  angles 0 29.406 0
  }
  {
-  coords 2630.041 72.611 1644.761
-  angles 0 51.446 0
+  coords 2467.086 89.669 1417.207
+  angles 0 29.029 0
  }
 }
 GenericEntity : "{F5B5DCF9D61A5A8C}PrefabsEditable/Auto/Props/Military/AmmoBoxes/EquipmentBoxStack/E_EquipmentBoxStack_US_01_V3.et" {
@@ -56,6 +56,6 @@ GenericEntity : "{F5B5DCF9D61A5A8C}PrefabsEditable/Auto/Props/Military/AmmoBoxes
    }
   }
  }
- coords 2626.57 72.588 1644.418
- angles 0 55.292 0
+ coords 2464.007 89.646 1415.565
+ angles 0 32.875 0
 }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Blufor/players.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Blufor/players.layer
@@ -1,64 +1,3 @@
-Vehicle _Series_LWB_Transport_Camo5 : "{098E31B006CAE0CE}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LWB_Transport_Camo.et" {
- components {
-  SCR_UniversalInventoryStorageComponent "{648B4DF41C28F11F}" {
-   MultiSlots {
-    MultiSlotConfiguration "{648B4DF41C28F112}" {
-     NumSlots 4
-    }
-    MultiSlotConfiguration "{669132EE1B4D07C0}" {
-     NumSlots 0
-    }
-    MultiSlotConfiguration "{692C00BF1BAA2F50}" {
-     SlotTemplate InventoryStorageSlot HandFlareWhite {
-      Prefab "{9361BEC03E52E6F8}Prefabs/Weapons/Handguns/Handheld Rocket Flares/Schermuly/Schermuly_Rocket_Flare_White.et"
-     }
-     NumSlots 6
-    }
-    MultiSlotConfiguration "{692C00BF1905EC12}" {
-     SlotTemplate InventoryStorageSlot HandFlareGreen {
-      Prefab "{5D694BB6F4A3819B}Prefabs/Weapons/Handguns/Handheld Rocket Flares/Schermuly/Schermuly_Rocket_Flare_Green.et"
-     }
-     NumSlots 3
-    }
-    MultiSlotConfiguration "{692C00BF196F157B}" {
-     SlotTemplate InventoryStorageSlot HandFlareRed {
-      Prefab "{CE4BDC1B0C4C6965}Prefabs/Weapons/Handguns/Handheld Rocket Flares/Schermuly/Schermuly_Rocket_Flare_Orange.et"
-     }
-     NumSlots 3
-    }
-    MultiSlotConfiguration "{692C00BCD8BB632C}" {
-     SlotTemplate LoadoutSlotInfo L85Ammo {
-      Prefab "{E882742A33858D5A}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_30rnd_RadwayGreen_Ball.et"
-     }
-     NumSlots 7
-    }
-    MultiSlotConfiguration "{692C00BCAC160CB2}" {
-     SlotTemplate InventoryStorageSlot GPMGBoxs {
-      Prefab "{D22DF40D07DA4615}Prefabs/Weapons/Magazines/Box_762x51_GPMG_100rnd_4Ball_1Tracer.et"
-     }
-     NumSlots 2
-    }
-    MultiSlotConfiguration "{692C00BC527D8ACB}" {
-     SlotTemplate InventoryStorageSlot HandGrenade {
-      Prefab "{CE179546A16382BA}Prefabs/Weapons/Grenades/Grenade_L2A2.et"
-     }
-     NumSlots 4
-    }
-    MultiSlotConfiguration "{692C00BC53B3850F}" {
-     SlotTemplate InventoryStorageSlot SmokeGrenade {
-      Prefab "{664048FA6BCACF5B}Prefabs/Weapons/Grenades/Grenade_WP_Base.et"
-     }
-     NumSlots 4
-    }
-   }
-   m_aSlotsToShow {
-   }
-  }
- }
- coords 2734.691 77.469 1629.957
- angles 0 -133.538 0
- m_sAttachmentGroupName "BAF_Coy_Weps"
-}
 $grp SCR_AIGroup : "{305C4B4F028B7994}Prefabs/Groups/BLUFOR/British Forces/1989/P/Light Infantry/Group_UK_1989_REG_RiflePHQ_P.et" {
  BAF_Plt_1_HQ {
   components {
@@ -67,8 +6,8 @@ $grp SCR_AIGroup : "{305C4B4F028B7994}Prefabs/Groups/BLUFOR/British Forces/1989/
     m_iPlatoonCallsign 1
    }
   }
-  coords 2690.96 77.533 1655.976
-  angles 0 109.156 0
+  coords 2613.51 62.581 1584.441
+  angles 0 60.139 0
   m_aUnitPrefabSlots {
    "{53973AC86DE14614}Prefabs/Characters/Factions/BLUFOR/UK_Army/1989/Light Infantry/P/Character_UK_1989_Regulars_PlatoonLeader_P.et"
    "{EF8064CC488769E5}Prefabs/Characters/Factions/BLUFOR/UK_Army/1989/Light Infantry/P/Character_UK_1989_Regulars_Sergeant_P.et"
@@ -78,13 +17,16 @@ $grp SCR_AIGroup : "{305C4B4F028B7994}Prefabs/Groups/BLUFOR/British Forces/1989/
  }
  BAF_MortarTeam {
   components {
+   AIFormationComponent "{507E9DC12F541FE6}" {
+    DefaultFormation "Line"
+   }
    PS_GroupCallsignAssigner "{63616C6C7369676E}" {
     Enabled 1
     m_iCompanyCallsign 9
    }
   }
-  coords 2639.9 73.582 1636.417
-  angles 0 -30.834 0
+  coords 2461.855 88.356 1408.262
+  angles -11.645 30.113 -3.514
   m_aUnitPrefabSlots {
    "{FD55D0E162A306AA}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/BritUnits/Custom_UK_1989_Regulars_MortarLeader_P.et"
    "{C3240E4E945A5CFC}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/BritUnits/Custom_UK_1989_Regulars_MortarCrew_P.et"
@@ -96,13 +38,16 @@ $grp SCR_AIGroup : "{305C4B4F028B7994}Prefabs/Groups/BLUFOR/British Forces/1989/
  }
  BAF_Plt_2_HQ {
   components {
+   AIFormationComponent "{507E9DC12F541FE6}" {
+    DefaultFormation "Line"
+   }
    PS_GroupCallsignAssigner "{63616C6C7369676E}" {
     Enabled 1
     m_iPlatoonCallsign 2
    }
   }
-  coords 2686.49 77.191 1644.262
-  angles 0 110.612 0
+  coords 2625.347 60.841 1577.818
+  angles 0 -118.94 0
  }
 }
 SCR_AIGroup BAF_Coy_HQ : "{4C7CAA5A6192809F}Prefabs/Groups/BLUFOR/British Forces/1989/P/Light Infantry/Group_UK_1989_REG_RifleCoyHQ_P.et" {
@@ -111,8 +56,8 @@ SCR_AIGroup BAF_Coy_HQ : "{4C7CAA5A6192809F}Prefabs/Groups/BLUFOR/British Forces
    Enabled 1
   }
  }
- coords 2696.809 77.531 1647.278
- angles 0 43.944 0
+ coords 2617.5 61.971 1576.397
+ angles 0 58.394 0
  m_sCustomNameSet "Company HQ"
 }
 $grp SCR_AIGroup : "{5F6B6EF4C6B9ACE7}Prefabs/Groups/BLUFOR/British Forces/1989/P/Light Infantry/Group_UK_1989_REG_RifleSection_P.et" {
@@ -124,8 +69,8 @@ $grp SCR_AIGroup : "{5F6B6EF4C6B9ACE7}Prefabs/Groups/BLUFOR/British Forces/1989/
     m_iSquadCallsign 1
    }
   }
-  coords 2690.053 77.594 1652.774
-  angles 0 109.187 0
+  coords 2615.333 62.32 1581.656
+  angles 0 60.17 0
  }
  BAF_Plt_1_Sqd_2 {
   components {
@@ -135,8 +80,8 @@ $grp SCR_AIGroup : "{5F6B6EF4C6B9ACE7}Prefabs/Groups/BLUFOR/British Forces/1989/
     m_iSquadCallsign 2
    }
   }
-  coords 2688.774 77.491 1649.864
-  angles 0 109.703 0
+  coords 2616.692 62.124 1578.781
+  angles 0 60.686 0
  }
  BAF_Plt_2_Sqd_1 {
   components {
@@ -146,8 +91,8 @@ $grp SCR_AIGroup : "{5F6B6EF4C6B9ACE7}Prefabs/Groups/BLUFOR/British Forces/1989/
     m_iSquadCallsign 1
    }
   }
-  coords 2685.896 77.008 1641.236
-  angles 0 110.643 0
+  coords 2621.318 61.856 1570.947
+  angles 0 61.626 0
  }
  BAF_Plt_2_Sqd_2 {
   components {
@@ -157,8 +102,8 @@ $grp SCR_AIGroup : "{5F6B6EF4C6B9ACE7}Prefabs/Groups/BLUFOR/British Forces/1989/
     m_iSquadCallsign 2
    }
   }
-  coords 2684.484 76.749 1638.383
-  angles 0 111.159 0
+  coords 2622.545 61.696 1568.014
+  angles 0 62.142 0
  }
 }
 SCR_AIGroup BAF_Coy_Weps : "{6EF8B3CEC83E4999}Prefabs/Groups/BLUFOR/British Forces/1989/P/Light Infantry/Group_UK_1989_REG_RifleMGDet_P.et" {
@@ -169,13 +114,6 @@ SCR_AIGroup BAF_Coy_Weps : "{6EF8B3CEC83E4999}Prefabs/Groups/BLUFOR/British Forc
    m_iSquadCallsign 3
   }
  }
- coords 2679.743 77.583 1635.851
- angles 0 107.473 0
- m_aUnitPrefabSlots {
-  "{14297AE2CB7BC202}Prefabs/Characters/Factions/BLUFOR/UK_Army/1989/Light Infantry/P/Character_UK_1989_Regulars_SectionCommander_P.et"
-  "{4755583337EF5985}Prefabs/Characters/Factions/BLUFOR/UK_Army/1989/Light Infantry/P/Character_UK_1989_Regulars_GPMG_No1_P.et"
-  "{38F1F906A4661D16}Prefabs/Characters/Factions/BLUFOR/UK_Army/1989/Light Infantry/P/Character_UK_1989_Regulars_AMG_P.et"
-  "{4755583337EF5985}Prefabs/Characters/Factions/BLUFOR/UK_Army/1989/Light Infantry/P/Character_UK_1989_Regulars_GPMG_No1_P.et"
-  "{38F1F906A4661D16}Prefabs/Characters/Factions/BLUFOR/UK_Army/1989/Light Infantry/P/Character_UK_1989_Regulars_AMG_P.et"
- }
+ coords 2623.308 61.207 1565.171
+ angles 0 58.456 0
 }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Blufor/vics.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Blufor/vics.layer
@@ -56,8 +56,8 @@ $grp Vehicle : "{098E31B006CAE0CE}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2709.713 77.471 1634.148
-  angles 0.639 44.417 0.627
+  coords 2626.409 62.792 1590.14
+  angles 10.784 56.511 3.448
   m_sAttachmentGroupName "BAF_Plt_1_HQ"
  }
  _Series_LWB_Transport_Camo2 {
@@ -117,8 +117,8 @@ $grp Vehicle : "{098E31B006CAE0CE}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2712.754 77.418 1631.066
-  angles 3.152 45.858 0.679
+  coords 2628.785 62.577 1586.516
+  angles 10.254 57.588 2.913
   m_sAttachmentGroupName "BAF_Plt_1_Sqd_1"
  }
  _Series_LWB_Transport_Camo3 {
@@ -178,8 +178,8 @@ $grp Vehicle : "{098E31B006CAE0CE}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2719.465 77.465 1624.793
-  angles 1.892 44.415 -0.652
+  coords 2634.137 62.243 1579.041
+  angles 10.809 56.085 3.368
   m_sAttachmentGroupName "BAF_Plt_2_HQ"
  }
  _Series_LWB_Transport_Camo7 {
@@ -239,8 +239,8 @@ $grp Vehicle : "{098E31B006CAE0CE}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2732.004 77.469 1632.914
-  angles 0 -133.538 0
+  coords 2620.587 63.352 1597.178
+  angles 9.892 55.646 5.01
   m_sAttachmentGroupName "BAF_Plt_2_Sqd_2"
  }
  _Series_LWB_Transport_Camo6 {
@@ -300,8 +300,8 @@ $grp Vehicle : "{098E31B006CAE0CE}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2716.184 77.428 1627.823
-  angles 0 43.486 0
+  coords 2631.512 62.451 1582.659
+  angles 10.581 55.235 1.267
   m_sAttachmentGroupName "BAF_Plt_1_Sqd_2"
  }
  _Series_LWB_Transport_Camo8 {
@@ -361,8 +361,8 @@ $grp Vehicle : "{098E31B006CAE0CE}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2729.137 77.491 1635.598
-  angles -0.622 -134.148 -0.643
+  coords 2623.044 63.071 1594.114
+  angles 10.652 55.064 4.398
   m_sAttachmentGroupName "BAF_Coy_HQ"
  }
  _Series_LWB_Transport_Camo9 {
@@ -422,9 +422,70 @@ $grp Vehicle : "{098E31B006CAE0CE}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2722.297 77.5 1622.107
-  angles 0 45.001 0
+  coords 2636.392 62.013 1575.848
+  angles 9.32 56.72 4.468
   m_sAttachmentGroupName "BAF_Plt_2_Sqd_1"
+ }
+ _Series_LWB_Transport_Camo5 {
+  components {
+   SCR_UniversalInventoryStorageComponent "{648B4DF41C28F11F}" {
+    MultiSlots {
+     MultiSlotConfiguration "{648B4DF41C28F112}" {
+      NumSlots 4
+     }
+     MultiSlotConfiguration "{669132EE1B4D07C0}" {
+      NumSlots 0
+     }
+     MultiSlotConfiguration "{692C00BF1BAA2F50}" {
+      SlotTemplate InventoryStorageSlot HandFlareWhite {
+       Prefab "{9361BEC03E52E6F8}Prefabs/Weapons/Handguns/Handheld Rocket Flares/Schermuly/Schermuly_Rocket_Flare_White.et"
+      }
+      NumSlots 6
+     }
+     MultiSlotConfiguration "{692C00BF1905EC12}" {
+      SlotTemplate InventoryStorageSlot HandFlareGreen {
+       Prefab "{5D694BB6F4A3819B}Prefabs/Weapons/Handguns/Handheld Rocket Flares/Schermuly/Schermuly_Rocket_Flare_Green.et"
+      }
+      NumSlots 3
+     }
+     MultiSlotConfiguration "{692C00BF196F157B}" {
+      SlotTemplate InventoryStorageSlot HandFlareRed {
+       Prefab "{CE4BDC1B0C4C6965}Prefabs/Weapons/Handguns/Handheld Rocket Flares/Schermuly/Schermuly_Rocket_Flare_Orange.et"
+      }
+      NumSlots 3
+     }
+     MultiSlotConfiguration "{692C00BCD8BB632C}" {
+      SlotTemplate LoadoutSlotInfo L85Ammo {
+       Prefab "{E882742A33858D5A}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_30rnd_RadwayGreen_Ball.et"
+      }
+      NumSlots 7
+     }
+     MultiSlotConfiguration "{692C00BCAC160CB2}" {
+      SlotTemplate InventoryStorageSlot GPMGBoxs {
+       Prefab "{D22DF40D07DA4615}Prefabs/Weapons/Magazines/Box_762x51_GPMG_100rnd_4Ball_1Tracer.et"
+      }
+      NumSlots 2
+     }
+     MultiSlotConfiguration "{692C00BC527D8ACB}" {
+      SlotTemplate InventoryStorageSlot HandGrenade {
+       Prefab "{CE179546A16382BA}Prefabs/Weapons/Grenades/Grenade_L2A2.et"
+      }
+      NumSlots 4
+     }
+     MultiSlotConfiguration "{692C00BC53B3850F}" {
+      SlotTemplate InventoryStorageSlot SmokeGrenade {
+       Prefab "{664048FA6BCACF5B}Prefabs/Weapons/Grenades/Grenade_WP_Base.et"
+      }
+      NumSlots 4
+     }
+    }
+    m_aSlotsToShow {
+    }
+   }
+  }
+  coords 2618.348 63.697 1600.488
+  angles 8.693 55.495 4.775
+  m_sAttachmentGroupName "BAF_Coy_Weps"
  }
 }
 $grp Vehicle : "{57FE9BCA625CA0E3}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LWB_Recce_M2HB.et" {
@@ -488,8 +549,8 @@ $grp Vehicle : "{57FE9BCA625CA0E3}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2717.286 77.513 1647.556
-  angles -1.266 -135.028 0.001
+  coords 2646.735 61.173 1562.278
+  angles 6.239 53.292 0.908
   m_sAttachmentGroupName "BAF_Plt_1_Sqd_1"
  }
  _Series_LWB_Recce_M2HB2 {
@@ -552,8 +613,8 @@ $grp Vehicle : "{57FE9BCA625CA0E3}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2720.386 77.479 1644.658
-  angles -0.637 -135.398 -0.629
+  coords 2649.381 61.108 1558.798
+  angles 6.252 52.448 0.816
   m_sAttachmentGroupName "BAF_Plt_2_Sqd_1"
  }
 }
@@ -613,8 +674,8 @@ $grp Vehicle : "{9B8FC88897DB630F}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2726.519 77.469 1638.354
-  angles 0 -133.16 0
+  coords 2640.488 61.599 1570.655
+  angles 8.209 55.32 4.03
   m_sAttachmentGroupName "BAF_Plt_2_Sqd_2"
  }
  _Series_LWB_Recce_Variant_1 {
@@ -672,8 +733,8 @@ $grp Vehicle : "{9B8FC88897DB630F}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LW
     }
    }
   }
-  coords 2723.749 77.469 1641.101
-  angles 0 -134.027 0
+  coords 2642.84 61.391 1567.542
+  angles 7.253 54.291 2.455
   m_sAttachmentGroupName "BAF_Plt_1_Sqd_2"
  }
 }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Breifings/breif_BAF.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Breifings/breif_BAF.layer
@@ -10,7 +10,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
  C_FriendlyForces_UK {
   coords 2904.489 63.313 1904.979
   m_sTitle "III. Friendly Forces"
-  m_sTextData "1x British motorized light infantry company of reduced strength, with attched battery of 2x 81mm mortars. Currently located at the staging area in the town of Arleville."
+  m_sTextData "1x British motorized light infantry company of reduced strength, with attched battery of 2x 81mm mortars. Currently located at the staging area near the town of Arleville."
   m_aVisibleForFactions {
    "UK"
   }
@@ -19,11 +19,12 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
  D_EnemyForces_UK {
   coords 2926.015 62.75 1904.571
   m_sTitle "IV. Enemy Forces"
-  m_sTextData "1x Russian motorized naval infantry platoon. Currently located somewhere in the town of Beauregard to the north."\
+  m_sTextData "1x Russian motorized naval infantry platoon. Supported by 2x BRDMs and 2x dedicated recon teams. Currently located somewhere in the town of Beauregard to the north."\
   ""\
   "Vehicles:"\
   "	4x PKM armed UAZ469,"\
-  "	6x unarmed open-top UAZ469,\"\""
+  "	6x unarmed open-top UAZ469,"\
+  "	2x BRDMs"
   m_aVisibleForFactions {
    "UK"
   }
@@ -46,7 +47,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
  F_MortarBattery_UK {
   coords 2918.025 63.124 1895.898
   m_sTitle "VI. M252 Mortar Battery"
-  m_sTextData "We have a local mortar battery consisting of 2x M252 81mm mortars. They are located at a prepared firing position along with their supply of ammunition down hill from the staging area. This area has been marked with a blue circle labled \"Mortars\". This mark is located directly between the two mortars, and is a reliable targeting referance."\
+  m_sTextData "We have a local mortar battery consisting of 2x M252 81mm mortars. They are located at a prepared firing position along with their supply of ammunition on Moss Hill to the south of the main staging area. This area has been marked with a blue circle labled \"Mortars\". This mark is located directly between the two mortars, and is a reliable targeting referance."\
   ""\
   "Battery ammuniton supply: 120x HE, 50x Illum, 50x Smoke"
   m_aVisibleForFactions {

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Breifings/breif_all.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Breifings/breif_all.layer
@@ -6,7 +6,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   ""\
   "45 minute TL after 5 minute setup. Russian force AO limited to red area, Britsh AO limited to map cover shape."\
   ""\
-  "Ratio 1.5 Britsh to 1.0 Russian"\
+  "Ratio 1.8 Britsh to 1.0 Russian"\
   ""\
   "Era: 1995"
   m_bEmptyFactionVisibility 1
@@ -36,6 +36,6 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   ""
   m_bEmptyFactionVisibility 1
   m_bShowForAnyFaction 1
-  m_iOrder 12
+  m_iOrder 13
  }
 }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Breifings/breif_opfor.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Breifings/breif_opfor.layer
@@ -10,7 +10,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
  C_FriendlyForces_Opfor {
   coords 2934.272 62.685 1891.814
   m_sTitle "III. Friendly Forces"
-  m_sTextData "1x Russian motorized naval infantry platoon. Augmented with 1x NSV HMG, dedicated recon teams, a suppy of anti-tank mines, and multiple light vehicles. Currently located in the staging area at the Beauregard docks."\
+  m_sTextData "1x Russian motorized naval infantry platoon. Augmented with 2x BRDMs, 2x dedicated recon teams, a suppy of anti-tank mines, and multiple light vehicles. Currently located in the staging area at the Beauregard docks."\
   ""\
   ""
   m_aVisibleForFactions {
@@ -24,9 +24,9 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTextData "We have a number of vehicle at our staging area. These vehicle have already been loaded with additional ammunition and supplies."\
   "	4x armed PKM UAZ469,"\
   "	6x unarmed UAZ469,"\
-  "	1x UAZ452 (van). "\
+  "	2x BRDM"\
   ""\
-  "We have a cache of extra supplies at our inital staging area. It is a stack of green crates located next to the concrete pipes. This cache contains: 12x TM62M anti-tank mines, hand flares, wrenches, backpacks, and extra SVD ammunition."
+  "We have a cache of extra supplies at our inital staging area. It is a stack of green crates located next to the concrete pipes. This cache contains: 12x TM62M anti-tank mines, hand flares, wrenches, backpacks, extra SVD ammunition, and 80x sand bags."
   m_aVisibleForFactions {
    "RHS_AFRF"
   }
@@ -51,23 +51,20 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTitle "VII. Deployment (READ)"
   m_sTextData "In addition to walking and driving the Russian team has teleports for deployment at their staging area. The teleport actions are located at the metal barrels next to the supply cache. The destinations are marked on the map with red pin markers. 30 seconds after the set up timer ends the teleports will be disabled."\
   ""\
-  "Teleports: Farm, Lighthouse, Shore, Timber North, Timber South, Front Center."
+  "Teleport locations: Farm, Lighthouse, Shore, Timber North, Timber South, Front Center."
   m_aVisibleForFactions {
    "RHS_AFRF"
   }
   m_iOrder 6
  }
- H_NSVTeamBreif_Opfor {
+ H_NSVTeamBreif_OpforOLD {
   coords 2929.056 62.638 1902.795
   m_sTitle "VIII. NSV Weapon Team (READ)"
   m_sTextData "The NSV HMG supplied to the Russian team is the scoped varitant. Both parts of the weapon (gun & tripod) are located on their dedicated units. Unless both of these roles are slotted the NSV will not be available, this is by design. If the choice is made to not slot them do not ask for a replacment NSV."\
   ""\
   "The UAZ452 van is the dedicated vehicle of the NSV team, it has been loaded with their entire supply of NSV ammuniton."\
   ""
-  m_aVisibleForFactions {
-   "RHS_AFRF"
-  }
-  m_iOrder 7
+  m_iOrder 30
  }
  B_Mission_Opfor {
   coords 2925.866 62.819 1899.991
@@ -86,7 +83,9 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "Company net: 42.0 Mhz"\
   "Company net alt: 42.2 Mhz"\
   "Backup net 1: 43.8 Mhz"\
-  "Backup net 2: 40.1 Mhz"\
+  "Backup net 2: 44.6 Mhz"\
+  "Spire 1 net: 41.1"\
+  "Spire 2 net 41.2"\
   ""\
   "Sec II. Callsigns"\
   ""\
@@ -98,7 +97,8 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "	Squad 2: 212"\
   "	Squad 3: 213"\
   "	Squad 4: 214"\
-  "	NSV HMG Team: Archer"\
+  "	BRDM 1: Spire 1"\
+  "	BRDM 2: Spire 2"\
   "	Scout Team 1: Fox 1"\
   "	Scout Team 2: Fox 2"\
   ""\

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Markers/Markers_BAF.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Markers/Markers_BAF.layer
@@ -1,9 +1,11 @@
 $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker.et" {
  BAFStaging_Mark {
-  coords 2738.476 77.461 1645.813
-  angles 0 90 0
-  m_MarkerColor 0.071 0.192 0.561 1
-  m_sQuadName "flag"
+  coords 2601.854 57.793 1566.254
+  angles 6.129 90.906 7.181
+  m_sImageSet "{1228936E5DB30403}UI/Textures/GroupManagement/FlagIcons/GroupFlagsBlufor.imageset"
+  m_sImageSetGlow "{D1BFDF90DD7A4E01}UI/Textures/GroupManagement/FlagIcons/GroupFlagsBlufor-outline.imageset"
+  m_MarkerColor 0.156 0.275 0.624 0.941
+  m_sQuadName "motorized-infantry"
   m_fWorldSize 55
   m_sDescription "BAF Staging"
   m_aVisibleForFactions {
@@ -11,9 +13,9 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
   }
  }
  BAFMortar_Mark {
-  coords 2628.812 72.602 1646.161
-  angles 0 0 0
-  m_MarkerColor 0.071 0.192 0.561 1
+  coords 2465.415 89.629 1418.032
+  angles 0 -22.417 0
+  m_MarkerColor 0.156 0.275 0.624 0.941
   m_sQuadName "circle"
   m_fWorldSize 25
   m_sDescription "Mortars"
@@ -29,7 +31,20 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
   m_MarkerColor 0.561 0.071 0.071 1
   m_sQuadName "motorized-infantry"
   m_fWorldSize 120
-  m_sDescription "Rus Motorized Force"
+  m_sDescription "AFRF Motorized Force"
+  m_aVisibleForFactions {
+   "UK"
+  }
+ }
+ MortarUnit_Mark {
+  coords 2406.869 87.622 1382.279
+  angles 0 90 2.684
+  m_sImageSet "{1228936E5DB30403}UI/Textures/GroupManagement/FlagIcons/GroupFlagsBlufor.imageset"
+  m_sImageSetGlow "{D1BFDF90DD7A4E01}UI/Textures/GroupManagement/FlagIcons/GroupFlagsBlufor-outline.imageset"
+  m_MarkerColor 0.156 0.275 0.624 0.941
+  m_sQuadName "mortar"
+  m_fWorldSize 55
+  m_sDescription "Mortar Battery"
   m_aVisibleForFactions {
    "UK"
   }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Markers/Markers_Opfor.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Markers/Markers_Opfor.layer
@@ -2,10 +2,12 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
  AFRFStaging_Mark {
   coords 3268.708 2.082 2880.71
   angles 0 90 0
-  m_MarkerColor 0.561 0.071 0.071 1
-  m_sQuadName "flag"
-  m_fWorldSize 55
-  m_sDescription "Rus Staging"
+  m_sImageSet "{7CD99D22C7AE8195}UI/Textures/GroupManagement/FlagIcons/GroupFlagsOpfor.imageset"
+  m_sImageSetGlow "{B9356E7B2E974DCD}UI/Textures/GroupManagement/FlagIcons/GroupFlagsOpfor-outline.imageset"
+  m_MarkerColor 0.558 0.07 0.07 0.941
+  m_sQuadName "motorized-infantry"
+  m_fWorldSize 60
+  m_sDescription "AFRF Staging"
   m_aVisibleForFactions {
    "RHS_AFRF"
   }
@@ -54,7 +56,7 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
    "RHS_AFRF"
   }
  }
- SP_Timbsou_Mark {
+ SP_TimbSou_Mark {
   coords 2611.625 111.07 2480.27
   angles 0 90 0
   m_MarkerColor 0.561 0.071 0.071 1

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Markers/TimberPathCover.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Markers/TimberPathCover.layer
@@ -1,0 +1,40 @@
+PolylineShapeEntity : "{A0468F86F76FCEE7}Prefabs/Logic/Map/TILW_MapShape.et" {
+ components {
+  TILW_MapShapeComponent "{6508F5526836BC09}" {
+   m_color 0.165 0.745 0.745 0.627
+  }
+ }
+ coords 2621.594 102.67 2598.748
+ Points {
+  ShapePoint "{695B72F37E93B6C7}" {
+   Position 37.022 -4.789 13.433
+  }
+  ShapePoint "{695B72F31DF63855}" {
+   Position 8.722 -2.26 43.729
+  }
+  ShapePoint "{695B72F3380A31A7}" {
+   Position -22.105 1.209 -5.656
+  }
+  ShapePoint "{695B72F33EEFCB34}" {
+   Position -48.794 4.951 -21.512
+  }
+  ShapePoint "{695B72F33E3CA04F}" {
+   Position -35.38 7.997 -55.936
+  }
+  ShapePoint "{695B72F33F7BBD32}" {
+   Position -2.89 -0.3 -31.329
+  }
+ }
+}
+PS_ManualMarker LoggedArea : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker.et" {
+ coords 2611.874 103.477 2584.194
+ m_MarkerColor 0 0 0 1
+ m_sQuadName "point-of-interest-2"
+ m_fWorldSize 35
+ m_sDescription "Cleared Area"
+ m_aVisibleForFactions {
+  "UK"
+  "RHS_AFRF"
+ }
+ m_bVisibleForEmptyFaction 1
+}

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Opfor/opfor_setuparea.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Opfor/opfor_setuparea.layer
@@ -5,7 +5,7 @@ GenericEntity : "{10E3BB141979D07C}PrefabsEditable/Auto/Props/Military/AmmoBoxes
    MultiSlots {
     MultiSlotConfiguration "{692951D900BC590B}" {
      SlotTemplate InventoryStorageSlot item1 {
-      Prefab "{CCC00D009D4949B0}Prefabs/Weapons/Explosives/Mine_TM62M/Mine_TM62M_base.et"
+      Prefab "{D6EF54367CECE1D9}Prefabs/Weapons/Explosives/Mine_TM62M/Mine_TM62M.et"
      }
      NumSlots 12
     }
@@ -22,7 +22,7 @@ GenericEntity : "{10E3BB141979D07C}PrefabsEditable/Auto/Props/Military/AmmoBoxes
     }
     MultiSlotConfiguration "{69295C2064F52EF1}" {
      SlotTemplate InventoryStorageSlot item6 {
-      Prefab "{443304F1EC50BC27}Prefabs/Items/Equipment/Backpacks/Backpack_Veshmeshok_Black.et"
+      Prefab "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
      }
      NumSlots 12
     }
@@ -55,12 +55,18 @@ GenericEntity : "{10E3BB141979D07C}PrefabsEditable/Auto/Props/Military/AmmoBoxes
       Prefab "{28FA34E692783ACB}Prefabs/Items/ACE_Facepaint_01_USSR.et"
      }
     }
+    MultiSlotConfiguration "{695B5C8B22FB0E90}" {
+     SlotTemplate InventoryStorageSlot SandBags {
+      Prefab "{07BC23F8D9223863}Prefabs/Items/Misc/Sandbags/Part_Sandbag_Burlap.et"
+     }
+     NumSlots 80
+    }
    }
    m_aSlotsToShow {
    }
   }
  }
- coords 3258.957 2 2902.922
+ coords 3259.886 2 2901.532
  angles 0 56.247 0
 }
 $grp GameEntity : "{616F4E93658E5A3A}Prefabs/Props/Military/Generators/GeneratorFloodlight_USSR_01.et" {
@@ -85,8 +91,8 @@ $grp GameEntity : "{616F4E93658E5A3A}Prefabs/Props/Military/Generators/Generator
     Enabled 0
    }
   }
-  coords 3262.882 2.032 2929.588
-  angles 0 -145.375 0
+  coords 3261.457 2 2928.484
+  angles 0 -126.349 0
  }
  {
   components {
@@ -124,24 +130,22 @@ $grp GameEntity : "{616F4E93658E5A3A}Prefabs/Props/Military/Generators/Generator
   coords 3243.195 2.128 2883.673
   angles 0 58.674 0
  }
-}
-GenericEntity : "{6FD54E69CFDD6B07}Prefabs/Props/Industrial/BarrelFuel_01_closed_old.et" {
- coords 3254.306 2 2908.775
-}
-$grp GenericEntity : "{7D52C517720EF2F5}Prefabs/Props/Industrial/BarrelMetal_01_blue.et" {
  {
-  coords 3257.027 2 2904.947
- }
- {
-  coords 3252.648 2 2911.135
+  components {
+   SCR_BaseInteractiveLightComponent "{5882B9E6B4EFC9DF}" {
+    m_eInitialLightState LIT
+   }
+   ActionsManagerComponent "{5616C184B222FC92}" {
+    Enabled 0
+   }
+  }
+  coords 3264.313 2 2918
+  angles 0 -140.425 0
  }
 }
-GenericEntity : "{7D52C517720EF2F6}Prefabs/Props/Industrial/BarrelMetal_01_grey.et" {
- coords 3256.094 2 2906.28
-}
-GenericEntity : "{DF3EF41CE4D441DE}Prefabs/Props/Industrial/BarrelMetal_01_rust.et" {
- coords 3255.181 2 2907.553
+GenericEntity : "{7D52C517720EF2F5}Prefabs/Props/Industrial/BarrelMetal_01_blue.et" {
+ coords 3258.398 2 2903.328
 }
 GenericEntity : "{F4BB6B6A0486F797}Prefabs/Props/Industrial/BarrelMetal_01_military.et" {
- coords 3253.469 2 2909.995
+ coords 3255.431 2 2906.347
 }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Opfor/players.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Opfor/players.layer
@@ -7,7 +7,7 @@ $grp SCR_AIGroup : "{026C981E5226FE0F}Prefabs/Groups/OPFOR/Russia/1990s/Naval In
     m_iSquadCallsign 2
    }
   }
-  coords 3257.279 2 2919.584
+  coords 3259.577 2 2915.554
   angles 0 146.122 0
   m_aUnitPrefabSlots {
    "{08F44C5DF10F7A6B}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_SL_P.et"
@@ -28,7 +28,7 @@ $grp SCR_AIGroup : "{026C981E5226FE0F}Prefabs/Groups/OPFOR/Russia/1990s/Naval In
     m_iSquadCallsign 3
    }
   }
-  coords 3255.144 2 2917.894
+  coords 3257.442 2 2913.864
   angles 0 146.902 0
   m_aUnitPrefabSlots {
    "{08F44C5DF10F7A6B}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_SL_P.et"
@@ -49,7 +49,7 @@ $grp SCR_AIGroup : "{026C981E5226FE0F}Prefabs/Groups/OPFOR/Russia/1990s/Naval In
     m_iSquadCallsign 4
    }
   }
-  coords 3253.005 2 2916.235
+  coords 3255.306 2 2912.207
   angles 0 146.902 0
   m_aUnitPrefabSlots {
    "{08F44C5DF10F7A6B}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_SL_P.et"
@@ -118,7 +118,7 @@ $grp SCR_AIGroup : "{026C981E5226FE0F}Prefabs/Groups/OPFOR/Russia/1990s/Naval In
     m_iSquadCallsign 6
    }
   }
-  coords 3250.865 2 2914.753
+  coords 3253.163 2 2910.723
   angles 0 146.902 0
   m_aUnitPrefabSlots {
    "{08F44C5DF10F7A6B}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_SL_P.et"
@@ -131,52 +131,59 @@ $grp SCR_AIGroup : "{026C981E5226FE0F}Prefabs/Groups/OPFOR/Russia/1990s/Naval In
   }
   m_sCustomNameSet "Rifle Squad"
  }
-}
-$grp SCR_AIGroup : "{AFA5F7679028B3B9}Prefabs/Groups/OPFOR/Russia/1990s/Naval Infantry 1993/P/AFRF_VMF_1993_PHQ_P.et" {
- RUS_PltHQ {
+ BRDM_Crew_1 {
   components {
    PS_GroupCallsignAssigner "{63616C6C7369676E}" {
     Enabled 1
-    m_iCompanyCallsign 1
-    m_iSquadCallsign 1
-   }
-  }
-  coords 3263.166 2 2902.451
-  angles 0 146.428 0
-  m_aUnitPrefabSlots {
-   "{02511C10471F89ED}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_PL_P.et"
-   "{74EACD8FE624465A}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_VSR_PSG_P.et"
-   "{5496F9828F07CB82}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_RTO_P.et"
-   "{ADF5843D9668B423}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_Medic_P.et"
-   "{ADF5843D9668B423}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_Medic_P.et"
-   "{ADF5843D9668B423}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_Medic_P.et"
-  }
- }
- RUS_NSVTeam {
-  components {
-   PS_GroupCallsignAssigner "{63616C6C7369676E}" {
-    Enabled 1
-    m_iCompanyCallsign 4
-    m_iPlatoonCallsign 12
+    m_iCompanyCallsign 5
+    m_iPlatoonCallsign 9
     m_iSquadCallsign 13
    }
-   SCR_EditableGroupComponent "{50D291F6C83FA532}" {
-    m_UIInfo SCR_EditableGroupUIInfo "{5298E609432D192D}" {
-     Name "NSV Weapon Team"
-    }
+  }
+  coords 3260.336 3.892 2890.944
+  angles 0 147.308 0
+  m_aUnitPrefabSlots {
+   "{C5CF6A51BC4B8854}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_VSR_CrewCommander_P.et"
+   "{A791953D82C8309A}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_FixedInven_VSR_CrewGunner_P.et"
+   "{099EA118A10313C3}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/1993/VMF/P/Character_RHS_RF_VMF_VSR_CrewDriver_P.et"
+  }
+  m_sCustomNameSet "BRDM Crew"
+ }
+ BRDM_Crew_2 {
+  components {
+   PS_GroupCallsignAssigner "{63616C6C7369676E}" {
+    Enabled 1
+    m_iCompanyCallsign 5
+    m_iPlatoonCallsign 10
+    m_iSquadCallsign 13
    }
   }
-  coords 3265.235 2 2906.18
-  angles 0 146.629 0
+  coords 3253.727 3.919 2885.938
+  angles 0 145.61 0
   m_aUnitPrefabSlots {
-   "{08F44C5DF10F7A6A}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/NSVTeam/Custom_VSR_NSV_TeamLeader_P.et"
-   "{730C15295DBF4541}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/NSVTeam/Custom_VSR_NSV_GunCarrier_P.et"
-   "{51E84E464BEE96EF}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/NSVTeam/Custom_VSR_NSV_TripodCarrier_P.et"
-   "{08CDD2A2D384D133}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/NSVTeam/Custom_VSR_NSV_AmmoBearer_P.et"
+   "{C5CF6A51BC4B8854}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_VSR_CrewCommander_P.et"
+   "{A791953D82C8309A}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_FixedInven_VSR_CrewGunner_P.et"
+   "{099EA118A10313C3}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/1993/VMF/P/Character_RHS_RF_VMF_VSR_CrewDriver_P.et"
   }
-  m_aStaticVehicles {
-   ""
+  m_sCustomNameSet "BRDM Crew"
+ }
+}
+SCR_AIGroup RUS_PltHQ : "{AFA5F7679028B3B9}Prefabs/Groups/OPFOR/Russia/1990s/Naval Infantry 1993/P/AFRF_VMF_1993_PHQ_P.et" {
+ components {
+  PS_GroupCallsignAssigner "{63616C6C7369676E}" {
+   Enabled 1
+   m_iCompanyCallsign 1
+   m_iSquadCallsign 1
   }
-  m_sCustomNameSet "NSV HMG Team"
+ }
+ coords 3261.291 3.57 2916.764
+ angles 0.542 145.354 -0.065
+ m_aUnitPrefabSlots {
+  "{02511C10471F89ED}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_PL_P.et"
+  "{74EACD8FE624465A}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_VSR_PSG_P.et"
+  "{5496F9828F07CB82}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_RTO_P.et"
+  "{ADF5843D9668B423}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_Medic_P.et"
+  "{ADF5843D9668B423}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_Medic_P.et"
+  "{ADF5843D9668B423}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/Custom_HelmetSwap_VSR_Medic_P.et"
  }
 }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Opfor/teleports.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Opfor/teleports.layer
@@ -1,9 +1,10 @@
 $grp GenericEntity : "{5B462DF843A26368}Prefabs/Utils/Interactions/TILW_TeleportInteraction.et" {
- Tele_Farm {
+ TeleMain_1 {
   components {
    ActionsManagerComponent "{62EF76E0D47ED96A}" {
     additionalActions {
      TILW_TeleportInteraction "{62EF76E608B6CB36}" {
+      ActionTitle "Farm"
       m_actionName "Teleport: Farm"
       m_locationName "SP_Farm_Mark"
       m_factionKeys {
@@ -11,84 +12,13 @@ $grp GenericEntity : "{5B462DF843A26368}Prefabs/Utils/Interactions/TILW_Teleport
       }
       m_conditionFlag "setupstart"
      }
-    }
-   }
-  }
-  coords 3257.029 3.3 2904.945
- }
- Tele_Lighthouse {
-  components {
-   ActionsManagerComponent "{62EF76E0D47ED96A}" {
-    additionalActions {
-     TILW_TeleportInteraction "{62EF76E608B6CB36}" {
-      m_actionName "Teleport: Lighthouse"
-      m_locationName "SP_LH_Mark"
-      m_factionKeys {
-       "RHS_AFRF"
+     TILW_TeleportInteraction "{695B72FC8E08655E}" {
+      ParentContextList {
+       "Interact_A"
       }
-      m_conditionFlag "setupstart"
-     }
-    }
-   }
-  }
-  coords 3256.117 3.278 2906.293
- }
- Tele_Shore {
-  components {
-   ActionsManagerComponent "{62EF76E0D47ED96A}" {
-    additionalActions {
-     TILW_TeleportInteraction "{62EF76E608B6CB36}" {
-      m_actionName "Teleport: Shore"
-      m_locationName "SP_Shore_Mark"
-      m_factionKeys {
-       "RHS_AFRF"
-      }
-      m_conditionFlag "setupstart"
-     }
-    }
-   }
-  }
-  coords 3255.18 3.27 2907.557
- }
- Tele_Timber_North {
-  components {
-   ActionsManagerComponent "{62EF76E0D47ED96A}" {
-    additionalActions {
-     TILW_TeleportInteraction "{62EF76E608B6CB36}" {
-      m_actionName "Teleport: Timber North"
-      m_locationName "SP_TimbNor_Mark"
-      m_factionKeys {
-       "RHS_AFRF"
-      }
-      m_conditionFlag "setupstart"
-     }
-    }
-   }
-  }
-  coords 3254.336 3.239 2908.799
- }
- Tele_Timber_South {
-  components {
-   ActionsManagerComponent "{62EF76E0D47ED96A}" {
-    additionalActions {
-     TILW_TeleportInteraction "{62EF76E608B6CB36}" {
-      m_actionName "Teleport: Timber South"
-      m_locationName "SP_Timbsou_Mark"
-      m_factionKeys {
-       "RHS_AFRF"
-      }
-      m_conditionFlag "setupstart"
-     }
-    }
-   }
-  }
-  coords 3253.481 3.278 2910.004
- }
- Tele_FrontCent {
-  components {
-   ActionsManagerComponent "{62EF76E0D47ED96A}" {
-    additionalActions {
-     TILW_TeleportInteraction "{62EF76E608B6CB36}" {
+      ActionTitle "Front Center"
+      Duration 1
+      "Sort Priority" 1
       m_actionName "Teleport: Front Center"
       m_locationName "SP_FrontCent_Mark"
       m_factionKeys {
@@ -96,9 +26,155 @@ $grp GenericEntity : "{5B462DF843A26368}Prefabs/Utils/Interactions/TILW_Teleport
       }
       m_conditionFlag "setupstart"
      }
+     TILW_TeleportInteraction "{695B72FC60E3D0DB}" {
+      ParentContextList {
+       "Interact_A"
+      }
+      ActionTitle "Lighthouse"
+      Duration 1
+      "Sort Priority" 2
+      m_actionName "Teleport: Lighthouse"
+      m_locationName "SP_LH_Mark"
+      m_factionKeys {
+       "RHS_AFRF"
+      }
+      m_conditionFlag "setupstart"
+     }
+     TILW_TeleportInteraction "{695B72FC61870F2B}" {
+      ParentContextList {
+       "Interact_A"
+      }
+      ActionTitle "Shore"
+      Duration 1
+      "Sort Priority" 3
+      m_actionName "Teleport: Shore"
+      m_locationName "SP_Shore_Mark"
+      m_factionKeys {
+       "RHS_AFRF"
+      }
+      m_conditionFlag "setupstart"
+     }
+     TILW_TeleportInteraction "{695B72FC614BC8A8}" {
+      ParentContextList {
+       "Interact_A"
+      }
+      ActionTitle "Timber North"
+      Duration 1
+      "Sort Priority" 4
+      m_actionName "Teleport: Timber North"
+      m_locationName "SP_TimbNor_Mark"
+      m_factionKeys {
+       "RHS_AFRF"
+      }
+      m_conditionFlag "setupstart"
+     }
+     TILW_TeleportInteraction "{695B72FC665A3294}" {
+      ParentContextList {
+       "Interact_A"
+      }
+      ActionTitle "Timber South"
+      Duration 1
+      "Sort Priority" 5
+      m_actionName "Teleport: Timber South"
+      m_locationName "SP_TimbSou_Mark"
+      m_factionKeys {
+       "RHS_AFRF"
+      }
+      m_conditionFlag "setupstart"
+     }
     }
    }
   }
-  coords 3252.622 3.277 2911.143
+  coords 3258.376 3.307 2903.299
+  angles 0 -33.208 0
+ }
+ TeleMain_2 {
+  components {
+   ActionsManagerComponent "{62EF76E0D47ED96A}" {
+    additionalActions {
+     TILW_TeleportInteraction "{62EF76E608B6CB36}" {
+      ActionTitle "Farm"
+      m_actionName "Teleport: Farm"
+      m_locationName "SP_Farm_Mark"
+      m_factionKeys {
+       "RHS_AFRF"
+      }
+      m_conditionFlag "setupstart"
+     }
+     TILW_TeleportInteraction "{695B72FC8E08655E}" {
+      ParentContextList {
+       "Interact_A"
+      }
+      ActionTitle "Front Center"
+      Duration 1
+      "Sort Priority" 1
+      m_actionName "Teleport: Front Center"
+      m_locationName "SP_FrontCent_Mark"
+      m_factionKeys {
+       "RHS_AFRF"
+      }
+      m_conditionFlag "setupstart"
+     }
+     TILW_TeleportInteraction "{695B72FC60E3D0DB}" {
+      ParentContextList {
+       "Interact_A"
+      }
+      ActionTitle "Lighthouse"
+      Duration 1
+      "Sort Priority" 2
+      m_actionName "Teleport: Lighthouse"
+      m_locationName "SP_LH_Mark"
+      m_factionKeys {
+       "RHS_AFRF"
+      }
+      m_conditionFlag "setupstart"
+     }
+     TILW_TeleportInteraction "{695B72FC61870F2B}" {
+      ParentContextList {
+       "Interact_A"
+      }
+      ActionTitle "Shore"
+      Duration 1
+      "Sort Priority" 3
+      m_actionName "Teleport: Shore"
+      m_locationName "SP_Shore_Mark"
+      m_factionKeys {
+       "RHS_AFRF"
+      }
+      m_conditionFlag "setupstart"
+     }
+     TILW_TeleportInteraction "{695B72FC614BC8A8}" {
+      ParentContextList {
+       "Interact_A"
+      }
+      ActionTitle "Timber North"
+      Duration 1
+      "Sort Priority" 4
+      m_actionName "Teleport: Timber North"
+      m_locationName "SP_TimbNor_Mark"
+      m_factionKeys {
+       "RHS_AFRF"
+      }
+      m_conditionFlag "setupstart"
+     }
+     TILW_TeleportInteraction "{695B72FC665A3294}" {
+      ParentContextList {
+       "Interact_A"
+      }
+      ActionTitle "Timber South"
+      Duration 1
+      "Sort Priority" 5
+      m_actionName "Teleport: Timber South"
+      m_locationName "SP_TimbSou_Mark"
+      m_factionKeys {
+       "RHS_AFRF"
+      }
+      m_conditionFlag "setupstart"
+     }
+    }
+   }
+  }
+  coords 3255.451 3.292 2906.345
+  angles 0 -33.208 0
  }
 }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Opfor/vics.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Opfor/vics.layer
@@ -634,70 +634,87 @@ Vehicle UAZ452_transport1 : "{1FBB492E86002BF5}Prefabs/Vehicles/Wheeled/UAZ452/U
    }
   }
  }
- coords 3257.552 1.944 2895.287
+ coords 1469.133 38 2931.758
  angles 0 146.868 0
- m_sAttachmentGroupName "RUS_NSVTeam"
 }
-Vehicle UAZ469_AGS1 : "{3F069520019E9C84}Prefabs/Vehicles/Wheeled/UAZ469/UAZ469_AGS.et" {
- components {
-  MeshObject "{51DAA09FEFBFC0E7}" {
-   Materials {
-    MaterialAssignClass "{693A286FAE7C594D}" {
-     SourceMaterial "UAZ469_Body"
-     AssignedMaterial "{B22C8E4C243BB8DE}Assets/Vehicles/Wheeled/UAZ469/Data/UAZ469_Body_RF.emat"
+$grp Vehicle : "{9AEDF323A812F9ED}Prefabs/Vehicles/Wheeled/BRDM2/BRDM2_AFRF.et" {
+ BRDM2_AFRF1 {
+  components {
+   RHS_GroupMaterialController "{65151D74DAFD4445}" {
+    m_aGroups {
+     RHS_MaterialGroupProperties "{65151D74A863B0CF}" {
+     }
+     RHS_MaterialGroupProperties "{65151D74B7FFFDEA}" {
+      m_iTextureID 1
+     }
+     RHS_MaterialGroupProperties "{65151D74B724A768}" {
+     }
+     RHS_MaterialGroupProperties "{65151D74B44285C1}" {
+     }
+    }
+   }
+   SCR_UniversalInventoryStorageComponent "{607E9AA3D83AA29D}" {
+    MultiSlots {
+     MultiSlotConfiguration "{695B72F65826BDB4}" {
+      SlotTemplate InventoryStorageSlot FlareWhite {
+       Prefab "{327103CB218E7CA1}Prefabs/Weapons/Flares/Flare_RSP30_white.et"
+      }
+      NumSlots 12
+     }
+     MultiSlotConfiguration "{695B72F659885721}" {
+      SlotTemplate InventoryStorageSlot FlareGreen {
+       Prefab "{FC79F6BDEB7F1BC2}Prefabs/Weapons/Flares/Flare_RSP30_green.et"
+      }
+      NumSlots 3
+     }
+     MultiSlotConfiguration "{695B72F659EC0814}" {
+      SlotTemplate InventoryStorageSlot FlareRed {
+       Prefab "{36218D5F0C7095E6}Prefabs/Weapons/Flares/Flare_RSP30_red.et"
+      }
+      NumSlots 3
+     }
     }
    }
   }
-  SCR_UniversalInventoryStorageComponent "{5AD4F813E67ECB5D}" {
-   MultiSlots {
-    MultiSlotConfiguration "{6064D13A1F7F88F4}" {
-     NumSlots 6
-    }
-    MultiSlotConfiguration "{693A286F2EBC36A0}" {
-     SlotTemplate InventoryStorageSlot "{693A286F21EBB2B2}" {
-      Prefab "{D78C667F59829717}Prefabs/Weapons/Magazines/Magazine_545x39_RPK_45rnd_4Ball_1Tracer.et"
-     }
-     NumSlots 4
-    }
-    MultiSlotConfiguration "{693A286F2C87AFA2}" {
-     SlotTemplate InventoryStorageSlot "{693A286F38D0EDA9}" {
-      Prefab "{BBB50A815A2F916B}Prefabs/Weapons/Magazines/Magazine_545x39_AK_30rnd_Ball.et"
-     }
-     NumSlots 7
-    }
-    MultiSlotConfiguration "{693A286F2CF72130}" {
-     SlotTemplate InventoryStorageSlot "{693A286CCB40B973}" {
-      Prefab "{327103CB218E7CA1}Prefabs/Weapons/Flares/Flare_RSP30_white.et"
-     }
-     NumSlots 4
-    }
-    MultiSlotConfiguration "{693A286F34444C2E}" {
-     SlotTemplate InventoryStorageSlot "{693A286CC791E1FB}" {
-      Prefab "{FC79F6BDEB7F1BC2}Prefabs/Weapons/Flares/Flare_RSP30_green.et"
-     }
-     NumSlots 2
-    }
-    MultiSlotConfiguration "{693A286F3584FCDC}" {
-     SlotTemplate InventoryStorageSlot "{693A286CDF6839FA}" {
-      Prefab "{36218D5F0C7095E6}Prefabs/Weapons/Flares/Flare_RSP30_red.et"
-     }
-     NumSlots 2
-    }
-    MultiSlotConfiguration "{693A286F35FD077C}" {
-     SlotTemplate InventoryStorageSlot "{693A286CD44E6B38}" {
-      Prefab "{645C73791ECA1698}Prefabs/Weapons/Grenades/Grenade_RGD5.et"
-     }
-     NumSlots 4
-    }
-    MultiSlotConfiguration "{693A286F35DAD1EF}" {
-     SlotTemplate InventoryStorageSlot "{693A286CE3B3BA01}" {
-      Prefab "{77EAE5E07DC4678A}Prefabs/Weapons/Grenades/Smoke_RDG2.et"
-     }
-     NumSlots 4
-    }
-   }
-  }
+  coords 3249.565 2.1 2886.582
+  angles 0 145.266 0
+  m_sAttachmentGroupName "BRDM_Crew_2"
  }
- coords 1474.481 38 2945.108
- angles 0 -122.462 0
+ BRDM2_AFRF2 {
+  components {
+   RHS_GroupMaterialController "{65151D74DAFD4445}" {
+    m_aGroups {
+     RHS_MaterialGroupProperties "{65151D74A863B0CF}" {
+     }
+     RHS_MaterialGroupProperties "{65151D74B7FFFDEA}" {
+     }
+    }
+   }
+   SCR_UniversalInventoryStorageComponent "{607E9AA3D83AA29D}" {
+    MultiSlots {
+     MultiSlotConfiguration "{695B72F65826BDB4}" {
+      SlotTemplate InventoryStorageSlot FlareWhite {
+       Prefab "{327103CB218E7CA1}Prefabs/Weapons/Flares/Flare_RSP30_white.et"
+      }
+      NumSlots 12
+     }
+     MultiSlotConfiguration "{695B72F659885721}" {
+      SlotTemplate InventoryStorageSlot FlareGreen {
+       Prefab "{FC79F6BDEB7F1BC2}Prefabs/Weapons/Flares/Flare_RSP30_green.et"
+      }
+      NumSlots 3
+     }
+     MultiSlotConfiguration "{695B72F659EC0814}" {
+      SlotTemplate InventoryStorageSlot FlareRed {
+       Prefab "{36218D5F0C7095E6}Prefabs/Weapons/Flares/Flare_RSP30_red.et"
+      }
+      NumSlots 3
+     }
+    }
+   }
+  }
+  coords 3256.551 1.947 2891.948
+  angles 0 147.544 0
+  m_sAttachmentGroupName "BRDM_Crew_1"
+ }
 }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Props/TreeStuff.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/Props/TreeStuff.layer
@@ -1,0 +1,129 @@
+Tree : "{0CA0547EB03759E1}Prefabs/Vegetation/Bush/b_rubus_idaeus_1s_collision.et" {
+ coords 2590.231 -0 2577.689
+}
+Tree : "{124518D13290A687}Prefabs/Vegetation/Bush/b_salix_cinerea_0_collision.et" {
+ coords 2599.618 0 2568.701
+ angles 0 -11.95 0
+}
+$grp Tree : "{1263BEF0B822A24A}Prefabs/Vegetation/Tree/t_pinus_sylvestris/t_pinus_sylvestris_stump_01.et" {
+ {
+  coords 2605.444 0.038 2577.139
+ }
+ {
+  coords 2621.846 0 2575.801
+  angles 0 31.429 0
+ }
+ {
+  coords 2622.216 0 2586.865
+ }
+ {
+  coords 2594.214 0.039 2579.74
+ }
+ {
+  coords 2596.554 -0.143 2568.811
+ }
+ {
+  coords 2600.122 -0.095 2575.919
+  angles 0 -21.897 0
+ }
+ {
+  coords 2606.248 0.1 2583.996
+  angles 0 -21.897 0
+ }
+ {
+  coords 2611.306 0.095 2599.975
+  angles 0 -21.897 0
+ }
+ {
+  coords 2614.015 -0.046 2593.265
+  angles 0 20.567 0
+ }
+ {
+  coords 2611.49 -0.019 2588.847
+  angles 0 -8.882 0
+ }
+ {
+  coords 2617.935 0.105 2586.66
+  angles 0 20.567 0
+ }
+ {
+  coords 2604.094 0.062 2599.678
+ }
+ {
+  coords 2607.416 0.094 2593.424
+  angles 0 16.933 0
+ }
+}
+Tree : "{5C594649DBDD5EAE}Prefabs/Vegetation/Tree/t_betula_pendula/t_betula_pendula_2s.et" {
+ coords 2606.311 0.025 2582.218
+}
+GenericEntity : "{630CDF78F2391CF8}Prefabs/Vegetation/Tree/Debris/T_trunk_debris_03.et" {
+ coords 2601.883 104.125 2575.218
+ angles -4.59 0 0
+}
+$grp GenericEntity : "{71F41635D2497C25}Prefabs/Vegetation/Tree/Debris/BranchTrash_con_01.et" {
+ {
+  coords 2601.851 104.216 2575.454
+  angles 0 28.312 0
+ }
+ {
+  coords 2630.881 101.551 2584.603
+ }
+}
+$grp GenericEntity : "{AB9F5821AA3F5C6F}Prefabs/Vegetation/Tree/Debris/dst_debris_con_03.et" {
+ {
+  coords 2631.929 101.329 2584.762
+  angles 4.361 0.683 8.907
+ }
+ {
+  coords 2632.926 101.28 2587.011
+  angles 9.411 -38.559 6.063
+ }
+ {
+  coords 2602.693 104.059 2578.193
+  angles -1.779 -0.139 4.469
+ }
+ {
+  coords 2603.218 104.218 2574.369
+  angles -3.921 32.754 2.787
+ }
+ {
+  coords 2617.524 102.727 2600.309
+ }
+}
+Tree : "{BA785041AC632123}Prefabs/Vegetation/Bush/b_salix_cinerea_1_collision.et" {
+ coords 2616.169 -0 2573.569
+}
+$grp GenericEntity : "{BBA4B6B98BB002A4}Prefabs/Vegetation/Tree/Debris/T_trunk_debris_05.et" {
+ {
+  coords 2632.385 101.39 2584.899
+  angles -4.314 0 0
+ }
+ {
+  coords 2613.981 102.706 2604.217
+  angles 0 -102.073 0
+ }
+}
+Tree : "{C98A6C1C2372354E}Prefabs/Vegetation/Bush/b_corylus_avellana_1_collision.et" {
+ coords 2600.896 -0 2559.58
+}
+$grp GenericEntity : "{EAC4A761421804BD}Prefabs/Vegetation/Tree/Debris/T_trunk_debris_01.et" {
+ {
+  coords 2631.689 101.302 2583.13
+  angles 0 34.485 0
+ }
+ {
+  coords 2631.236 102.573 2631.651
+  angles -3.13 11.55 0
+ }
+}
+$grp GenericEntity : "{EC86208E5412E6D2}Prefabs/Vegetation/Tree/Debris/BranchTrash_dec_01.et" {
+ {
+  coords 2601.768 104.461 2573.957
+  angles -2.652 -0.29 6.249
+ }
+ {
+  coords 2615.035 102.366 2606.631
+  angles 0 -2.991 0
+ }
+}

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/System/AO_zones.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/System/AO_zones.layer
@@ -7,6 +7,15 @@ $grp PolylineShapeEntity : "{85222A2744768C81}Prefabs/Logic/AOLimit/TILW_AOLimit
   }
   coords 2758.56 87.307 2214.286
   Points {
+   ShapePoint "{695B72EBFAFCEC58}" {
+    Position -247.278 9.194 -298.489
+   }
+   ShapePoint "{695B72EBF39B19EE}" {
+    Position -221.261 18.161 -164.21
+   }
+   ShapePoint "{695B72EBEA8CC9B1}" {
+    Position -201.16 49.254 73.023
+   }
    ShapePoint "{69281B28847F5A42}" {
     Position -201.97 43.634 136.304
    }
@@ -38,16 +47,19 @@ $grp PolylineShapeEntity : "{85222A2744768C81}Prefabs/Logic/AOLimit/TILW_AOLimit
     Position 1126.608 -108.77 508.129
    }
    ShapePoint "{69281B2F830EA09C}" {
-    Position 831.179 -91.43 -300.893
+    Position 899.351 -122.431 -125.987
    }
-   ShapePoint "{693A287E1B4EA5E9}" {
-    Position 541.18 -59.258 -500.825
+   ShapePoint "{695B72E83BEEBBAE}" {
+    Position 835.732 -87.571 -582.504
    }
-   ShapePoint "{69281B28E11641B8}" {
-    Position 14.872 -31.448 -754.932
+   ShapePoint "{695B72E82E23C449}" {
+    Position 323.923 -25.759 -671.265
    }
-   ShapePoint "{69281B28FC962B79}" {
-    Position -177.446 -26.988 -621.66
+   ShapePoint "{695B72EBC3192B8E}" {
+    Position -371.146 8.033 -934.028
+   }
+   ShapePoint "{695B72EB9AD48CFF}" {
+    Position -585.091 -33.794 -750.101
    }
   }
  }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/System/EntityDeleters.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/System/EntityDeleters.layer
@@ -1,35 +1,53 @@
 $grp PK_EntityDeleter {
- BritCarArea_1 {
-  coords 2714.1 77.347 1633.906
-  m_fRadius 25
-  m_prefabFilterList {
-   "{A240B5FCD17D5686}Prefabs/Props/Construction/GarbageStack_01/GarbageStack_01_Medium.et"
-   "{E7117284012B39A4}Prefabs/Props/Garbage/Bins/TrashBin_02_patched.et"
-   "{F7919E01B9B17B3E}Prefabs/Structures/Ruins/HouseRuins/HouseRuin_01/HouseRuin_01_BrickPile_Small.et"
-   "{B3B8F051A298B68E}Prefabs/Vegetation/Plant/p_carduus_acanthoides_0s.et"
-   "{CA75EC62F90F5614}Prefabs/Vegetation/Plant/p_artemisia_vulgaris_0s.et"
-   "{3F0D0593590519DA}Prefabs/Props/Garbage/Tires/TirePile_01_medium.et"
-   "{ECAF8FE9FFC28643}Prefabs/Props/Agriculture/Farm/HaystackDryer_01.et"
-   "{DE59CB05202006E8}Prefabs/Props/Agriculture/CultivatorWreck_01.et"
-   "{B32F6E7F44FABD3F}Prefabs/Structures/Infrastructure/Power/Utility/UtilityCabinet_02/UtilityCabinet_02.et"
-   "{C7E893F48CE5848E}Prefabs/Structures/Signs/Warnings/SignNoEntryVehicle_01_pole.et"
-   "{D9DF1D13919F19A0}Prefabs/Vegetation/Bush/b_rosa_canina_0s.et"
-   "{2B532EC12F7FB1DE}Prefabs/Vegetation/Tree/t_betula_pendula/t_betula_pendula_3s.et"
-   "{C98A6C1C2372354E}Prefabs/Vegetation/Bush/b_corylus_avellana_1_collision.et"
-   "{3042375F6C45AF68}Prefabs/Vegetation/Plant/p_urtica_dioica_0s.et"
-   "{E680B16A04C3FDEA}PrefabLibrary/DefaultLibrary/Props/Infrastructure/UtilityCabinet_02.et"
-   "{C7E893F48CE5848E}Prefabs/Structures/Signs/Warnings/SignNoEntryVehicle_01_pole.et"
-  }
- }
- BritFenceRemove_1 {
-  coords 2681.586 73.321 1646.927
+ BritStaging_2 {
+  coords 2610.22 42.216 1569.367
+  m_fRadius 65
   m_prefabFilterList {
    "{A0034468130DC93D}Prefabs/Structures/Walls/Pole/PoleFence_02/PoleFence_02_4m_A.et"
    "{E6C231BE778A880F}Prefabs/Structures/Walls/Pole/PoleFence_02/PoleFence_02_8m_B.et"
    "{035E7D477B6F1F64}Prefabs/Structures/Walls/Pole/PoleFence_02/PoleFence_02_8m_C.et"
    "{8A96055ECB4E0721}Prefabs/Structures/Walls/Pole/PoleFence_02/PoleFence_02_8m_A.et"
    "{3E6A587F0E039653}Prefabs/Structures/Walls/Pole/PoleFence_02/PoleFence_02_8m_D.et"
-   "{221ABC927C672E4E}Prefabs/World/DefaultWorld/GenericTerrain_Default.et"
+  }
+  m_bPreviewShape 0
+ }
+ TimberPathClear_1 {
+  coords 2598.903 106.681 2573.873
+  m_fRadius 30
+  m_prefabFilterList {
+   "{A975A81D02F4862C}Prefabs/Vegetation/Tree/t_picea_abies/t_picea_abies_2s.et"
+  }
+  m_bPreviewShape 0
+ }
+ TimberPathClear_2 {
+  coords 2627.495 97.321 2615.829
+  m_fRadius 22
+  m_prefabFilterList {
+   "{A975A81D02F4862C}Prefabs/Vegetation/Tree/t_picea_abies/t_picea_abies_2s.et"
+   "{20DF6F32A326584B}Prefabs/Vegetation/Tree/t_pinus_sylvestris/t_pinus_sylvestris_3f_high.et"
+   "{6DF33B3CBC51D6D9}Prefabs/Vegetation/Tree/t_picea_abies/t_picea_abies_3f.et"
+  }
+  m_bPreviewShape 0
+ }
+ TimberPathClear_3 {
+  coords 2608.586 102.523 2593.667
+  m_fRadius 10
+  m_prefabFilterList {
+   "{A975A81D02F4862C}Prefabs/Vegetation/Tree/t_picea_abies/t_picea_abies_2s.et"
+   "{20DF6F32A326584B}Prefabs/Vegetation/Tree/t_pinus_sylvestris/t_pinus_sylvestris_3f_high.et"
+   "{6DF33B3CBC51D6D9}Prefabs/Vegetation/Tree/t_picea_abies/t_picea_abies_3f.et"
+  }
+  m_bPreviewShape 0
+ }
+ BritStaging_3 {
+  coords 2467.435 76.499 1412.203
+  m_fRadius 30
+  m_prefabFilterList {
+   "{A43BE7E364B5CD67}Prefabs/Vegetation/Bush/b_juniperus_communis_2w.et"
+   "{8A403C31EFCF153F}Prefabs/Rocks/Granite/GraniteStone_03.et"
+   "{D9DF1D13919F19A0}Prefabs/Vegetation/Bush/b_rosa_canina_0s.et"
+   "{81EE8FAE7539DAA1}Prefabs/Vegetation/Bush/b_juniperus_communis_0.et"
+   "{6C454FA2B0FAFAEE}Prefabs/Vegetation/Bush/b_juniperus_communis_1s.et"
   }
   m_bPreviewShape 0
  }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/System/objectives.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/System/objectives.layer
@@ -83,12 +83,8 @@ TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramewor
     TILW_DeleteEntitiesInstruction "{693969BADE23D7DF}" {
      m_executionDelay 330
      m_entityNames {
-      "Tele_Farm"
-      "Tele_Lighthouse"
-      "Tele_Shore"
-      "Tele_Timber_North"
-      "Tele_Timber_South"
-      "Tele_FrontCent"
+      "TeleMain_1"
+      "TeleMain_2"
      }
     }
    }

--- a/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/default.layer
+++ b/worlds/RedTheKnown/BritsAtBeauregard/BritsAtBeauregard_Layers/default.layer
@@ -34,19 +34,22 @@ PS_GameModeCoop PS_GameMode_Lobby_GC1 : "{4CFD54745CD45673}Prefabs/MP/Modes/PS_G
        SCR_CallsignInfo "{55CCB7928223BB00}" {
         m_sCallsign "Archer"
        }
+       SCR_CallsignInfo "{55CCB79285FF31DB}" {
+        m_sCallsign "Spire"
+       }
        SCR_CallsignInfo "{69294101AC3F78B5}" {
         m_sCallsign "Fox"
        }
       }
       m_aPlatoonNames {
        SCR_CallsignInfo "{6929410196CA49EE}" {
-        m_sCallsign "-1"
+        m_sCallsign " 1"
        }
        SCR_CallsignInfo "{6929410197A602AF}" {
-        m_sCallsign "-2"
+        m_sCallsign " 2"
        }
        SCR_CallsignInfo "{6929410197E042FA}" {
-        m_sCallsign "-3"
+        m_sCallsign " 3"
        }
        SCR_CallsignInfo "{692970CFAA3F9023}" {
        }

--- a/worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_FixedInven_VSR_CrewGunner_P.et
+++ b/worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_FixedInven_VSR_CrewGunner_P.et
@@ -1,0 +1,21 @@
+SCR_ChimeraCharacter : "{8E461907FA345841}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/1993/VMF/P/Character_RHS_RF_VMF_VSR_CrewGunner_P.et" {
+ ID "520EC961A090B1EE"
+ components {
+  SCR_InventoryStorageManagerComponent "{520EA1D2DB118DE5}" {
+   InitialInventoryItems {
+    ItemsInitConfigurationItem "{6062F65EC3690C43}" {
+     TargetStorage "Jacket/Jacket_M88_VSR.et"
+     PrefabsToSpawn {
+      "{7CEF68E2BC68CE71}Prefabs/Items/Equipment/Compass/Compass_Adrianov.et" "{F849217AB3BA88BE}Prefabs/Items/Equipment/Maps/Map_Paper_01/PaperMap_01_folded_USSR.et" "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et" "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et" "{80E75A71C29190DB}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_USSR_01.et" "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et" "{062E2F1D7F6739D6}Prefabs/Items/Equipment/Accessories/ETool_MPL50/ETool_MPL50_FreeRoamBuilding_Gadget.et" "{632CAEF08C102091}Prefabs/Items/Medicine/Splint_01/GC_Splint_01_Base.et"
+     }
+    }
+    ItemsInitConfigurationItem "{695B5C884B725F1E}" {
+     TargetStorage "Pants/Pants_M88_VSR.et"
+     PrefabsToSpawn {
+      "{E1A5D4B878AA8980}Prefabs/Items/Equipment/Radios/RU/Radio_R148.et"
+     }
+    }
+   }
+  }
+ }
+}

--- a/worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_FixedInven_VSR_CrewGunner_P.et.meta
+++ b/worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_FixedInven_VSR_CrewGunner_P.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{A791953D82C8309A}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/1993/VMF/P/Custom_Character_RHS_RF_VMF_VSR_CrewGunner_P.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_VSR_CrewCommander_P.et
+++ b/worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_VSR_CrewCommander_P.et
@@ -1,0 +1,38 @@
+SCR_ChimeraCharacter : "{8E461907FA345841}Prefabs/Characters/Factions/OPFOR/RHS_AFRF/1993/VMF/P/Character_RHS_RF_VMF_VSR_CrewGunner_P.et" {
+ ID "520EC961A090B1EE"
+ components {
+  SCR_CharacterInventoryStorageComponent "{520EA1D2DB118DAC}" {
+   components {
+    SCR_EquipmentStorageComponent "{56B49DA9722B635D}" {
+     InitialStorageSlots {
+      SCR_EquipmentStorageSlot BinocularSlot {
+       Prefab "{243948B23D90BECB}Prefabs/Items/Equipment/Binoculars/Binoculars_B8/Binoculars_B8.et"
+      }
+     }
+    }
+   }
+  }
+  SCR_EditableCharacterComponent "{520EA1D2F659C85C}" {
+   m_UIInfo SCR_EditableEntityUIInfo "{5298E609432D192D}" {
+    Name "Vehicle Commander"
+    Icon "{A26C465A6AE2AA17}UI/Textures/Editor/EditableEntities/Characters/EditableEntity_Character_Leader.edds"
+   }
+  }
+  SCR_InventoryStorageManagerComponent "{520EA1D2DB118DE5}" {
+   InitialInventoryItems {
+    ItemsInitConfigurationItem "{6062F65EC3690C43}" {
+     TargetStorage "Jacket/Jacket_M88_VSR.et"
+     PrefabsToSpawn {
+      "{7CEF68E2BC68CE71}Prefabs/Items/Equipment/Compass/Compass_Adrianov.et" "{F849217AB3BA88BE}Prefabs/Items/Equipment/Maps/Map_Paper_01/PaperMap_01_folded_USSR.et" "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et" "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et" "{80E75A71C29190DB}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_USSR_01.et" "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et" "{062E2F1D7F6739D6}Prefabs/Items/Equipment/Accessories/ETool_MPL50/ETool_MPL50_FreeRoamBuilding_Gadget.et" "{632CAEF08C102091}Prefabs/Items/Medicine/Splint_01/GC_Splint_01_Base.et"
+     }
+    }
+    ItemsInitConfigurationItem "{695B5C88B81DC9DA}" {
+     TargetStorage "Pants/Pants_M88_VSR.et"
+     PrefabsToSpawn {
+      "{E1A5D4B878AA8980}Prefabs/Items/Equipment/Radios/RU/Radio_R148.et"
+     }
+    }
+   }
+  }
+ }
+}

--- a/worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_VSR_CrewCommander_P.et.meta
+++ b/worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/Custom_VSR_CrewCommander_P.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{C5CF6A51BC4B8854}worlds/RedTheKnown/BritsAtBeauregard/Prefabs/OpforUnits/VicCrew/CustomCommander_Character_RHS_RF_VMF_VSR_CrewGunner_P.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
- Major Changes:

Swapped out Russian NSV team for 2x BRDMs, this increased Rus player count by +2

Remade Russian teleport interactions to scroll through multiple interactions rather than being 6 separate ones, now there are two teleport interactions either of which can be used to go to any of the deployment locations. Only reason there is two instead of one is to make it easier to use with higher player counts.

Used entity deleters and TILW map shape to clear trees and mark an area of Timber Ridge, makes British advance on the side slightly easier especially with vehicles. Also added props to make the clearing seem like an area that had been logged, rather than just a random space with 0 trees for no reason.

- Minor changes:

Ratio changed to 1.8 British : 1.0 Russian (was 1.5 British). At max player count the ratio cant be perfectly maintained but I doubt it will ever be played at max players, and it should be balanced regardless due to all of the assets of both teams being in use in that situation.

Updated .config to reflect +2 players, min stayed the same

Adjusted AO slightly

Moved British starting area back for more concealed movent at start of mission, also moved back British mortar position 

Adjusted some markers for better clarity 

Added some sandbags to Russian supply cache

Adjusted and updated briefing for clarity and due to new BRDM units

Added two new custom units to Russians, vic crew commander and adjusted vic crew gunner. The Russian naval infantry just doesn't have a crew commander so I just inherited from the driver and changed the name + icon, The crew gunner has a broken inventory that doesn't assign items properly so their map and compass didn't spawn so I fixed that with the adjusted version.
