### PR TITLE
Cimic house update

### DIFF
--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/BLUFOR/Briefs.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/BLUFOR/Briefs.layer
@@ -63,6 +63,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTextData "<h2>COMPOSITION & DISPOSITION</h2>  "\
   "We are 2nd Platoon, Y Company, 1st Battalion, Princess of Wales's Royal Regiment (1 PWRR).  "\
   "Our force consists of 30 personnel currently occupying our platoon house (CIMIC House) at GRID: 043039"\
+  "We are restricted to our compound."\
   ""\
   "<h2>STRENGTHS & CAPABILITIES</h2> "\
   "• Three GPMG static machine guns have been set up around the compound within bunkers."\

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/BLUFOR/Briefs.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/BLUFOR/Briefs.layer
@@ -35,7 +35,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   ""\
   "<h2>PASSWORDS</h2>"\
   "All can be changed at CO's discretion."\
-  "• <b>Challenge:</b> Spectacal | <b>Password:</b> Paget"\
+  "• <b>Challenge:</b> Spectacle | <b>Password:</b> Paget"\
   "• Running password: 2"
   m_aVisibleForFactions {
    "UK"

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/OPFOR/AI.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/OPFOR/AI.layer
@@ -1,10 +1,10 @@
 $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpawner.et" {
  AI_HQ1 {
-  coords 3935.483 17.97 4583.932
+  coords 3824.995 17.844 4003.319
   angles 0 129.308 0
   m_prefab "{03B12A3C43CCACFF}Prefabs/Groups/OPFOR/GC_IRAQ/2000/Standard dress/Group_IRAQ_2000_PHQ.et"
   m_spawnTimings {
-   3
+   20
    300
    600
    950
@@ -12,6 +12,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1560
   }
   m_waypointNames {
+   "FM3"
    "Attack1"
   }
  }
@@ -28,6 +29,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1510
   }
   m_waypointNames {
+   "FM8"
    "Attack1"
   }
  }
@@ -44,15 +46,16 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1500
   }
   m_waypointNames {
+   "FM9"
    "Attack1"
   }
  }
  AI_AT1 {
-  coords 4311.471 17.844 4451.207
+  coords 4091.705 17.841 4223.518
   angles 0 -126.55 0
   m_prefab "{936293AB24844C2C}Prefabs/Groups/OPFOR/GC_IRAQ/2000/Standard dress/Group_IRAQ_2000_ATGroup.et"
   m_spawnTimings {
-   1
+   5
    300
    680
    900
@@ -60,6 +63,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1555
   }
   m_waypointNames {
+   "FM1"
    "Attack1"
   }
  }
@@ -76,6 +80,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1520
   }
   m_waypointNames {
+   ""
    "Attack1"
   }
  }
@@ -92,6 +97,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1500
   }
   m_waypointNames {
+   "FM4"
    "Attack1"
   }
  }
@@ -108,6 +114,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1500
   }
   m_waypointNames {
+   "FM6"
    "Attack1"
   }
  }
@@ -116,7 +123,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
   angles 0 129.308 0
   m_prefab "{AF540CE6219CCC3B}Prefabs/Groups/OPFOR/GC_IRAQ/2000/Standard dress/Group_IRAQ_2000_RifleSquad.et"
   m_spawnTimings {
-   11
+   30
    300
    600
    900
@@ -124,11 +131,12 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1500
   }
   m_waypointNames {
+   "FM11"
    "Attack1"
   }
  }
  AI_AT2 {
-  coords 4881.823 15.36 4366.429
+  coords 4881.823 14.841 4366.429
   angles 0 -126.55 0
   m_prefab "{936293AB24844C2C}Prefabs/Groups/OPFOR/GC_IRAQ/2000/Standard dress/Group_IRAQ_2000_ATGroup.et"
   m_spawnTimings {
@@ -140,6 +148,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1500
   }
   m_waypointNames {
+   "FM2"
    "Attack1"
   }
  }
@@ -156,11 +165,12 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1500
   }
   m_waypointNames {
+   "FM5"
    "Attack1"
   }
  }
  AI_Rifle5 {
-  coords 3786.412 19.199 3679.805
+  coords 3902.604 20.756 3636.482
   angles 0 129.308 0
   m_prefab "{AF540CE6219CCC3B}Prefabs/Groups/OPFOR/GC_IRAQ/2000/Standard dress/Group_IRAQ_2000_RifleSquad.et"
   m_spawnTimings {
@@ -172,6 +182,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1530
   }
   m_waypointNames {
+   "FM12"
    "Attack1"
   }
  }
@@ -188,6 +199,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    1500
   }
   m_waypointNames {
+   "FM7"
    "Attack1"
   }
  }
@@ -313,6 +325,23 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
     }
    }
    m_noTurretDismount 1
+  }
+ }
+ AI_Rifle6 {
+  coords 3835.462 18.695 4067.212
+  angles 0 114.067 0
+  m_prefab "{AF540CE6219CCC3B}Prefabs/Groups/OPFOR/GC_IRAQ/2000/Standard dress/Group_IRAQ_2000_RifleSquad.et"
+  m_spawnTimings {
+   60
+   300
+   630
+   900
+   1200
+   1510
+  }
+  m_waypointNames {
+   "FM13"
+   "Attack1"
   }
  }
 }

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/OPFOR/WP.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/OPFOR/WP.layer
@@ -1,12 +1,200 @@
+$grp SCR_AIWaypoint : "{06E1B6EBD480C6E0}Prefabs/AI/Waypoints/AIWaypoint_ForcedMove.et" {
+ FM1 {
+  coords 4089.902 17.844 4223.595
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM2 {
+  coords 4880.095 13.439 4368.422
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM3 {
+  coords 3824.26 17.844 4001.285
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM4 {
+  coords 4323.873 17.844 3444.989
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM5 {
+  coords 4886.411 3.57 4079.229
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM6 {
+  coords 4188.183 17.844 3567.835
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM7 {
+  coords 4808.328 1.586 3722.141
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM8 {
+  coords 3827.72 17.844 4477.825
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM9 {
+  coords 4232.39 17.844 4633.074
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM10 {
+  coords 4469.511 17.844 4473.225
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM11 {
+  coords 4526.927 17.844 3487.576
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM12 {
+  coords 3902.745 20.786 3635.973
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+ FM13 {
+  coords 3835.424 18.67 4066.597
+  m_aSettings {
+   SCR_AIGroupCombatModeSetting "{69F6FEC2C42F1299}" {
+   }
+   SCR_AIGroupFormationSetting "{69F6FEC13876F1B4}" {
+    m_eFormation Line
+   }
+   SCR_AICharacterMovementSpeedSetting "{69F6FEC13E45AC0A}" {
+    m_eCause COMBAT
+    m_eSpeed SPRINT
+   }
+  }
+ }
+}
 SCR_EntityWaypoint Attack1 : "{1B0E3436C30FA211}Prefabs/AI/Waypoints/AIWaypoint_Attack.et" {
  coords 4348.01 17.844 3902.4
  angles 0 41.494 0
  CompletionRadius 20
- m_fPriorityLevel 250
  m_aSettings {
   SCR_AIGroupCombatModeSetting "{69E8F113F2DA06AA}" {
   }
   SCR_AIGroupFormationSetting "{69E8F12CBEE75D70}" {
+   m_eFormation Line
+  }
+  SCR_AICharacterMovementSpeedSetting "{69F6F34C7B8FE9AE}" {
+   m_eCause COMBAT
+   m_eSpeed SPRINT
   }
  }
 }

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/PROPS/CimicHouses/Defences.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/PROPS/CimicHouses/Defences.layer
@@ -1,3 +1,7 @@
+GenericEntity : "{039684B010E892B9}Prefabs/Models/props/tem_pillow3.et" {
+ coords 4339.724 21.204 3895.495
+ angles 0 -67.413 0
+}
 $grp StaticModelEntity : "{19D504D46A48529A}Prefabs/Structures/Military/Fortifications/Trenches/ACE_TrenchSegment_01_short.et" {
  {
   components {
@@ -257,6 +261,18 @@ $grp GenericEntity : "{21D83950DF36F250}Prefabs/Props/Military/Sandbags/Sandbag_
   coords 4332.755 20.954 3913.411
   angles 0 133.085 0
  }
+ {
+  components {
+   TILW_NavmeshRegenComponent "{69F6F348B6C7BD34}" {
+   }
+  }
+  coords 4319.502 21.119 3902.601
+  angles 0 -48.642 0
+ }
+}
+GenericEntity : "{2F78465F2439D72F}Prefabs/Props/Furniture/Carpet_03_base_anizay_test.et" {
+ coords 4339.212 21.204 3894.157
+ angles 0 -50.045 0
 }
 GenericEntity : "{43366695B8CC85A2}Prefabs/Props/Military/H Barrier/Hesco barrier Triple v2.et" {
  components {
@@ -315,13 +331,39 @@ StaticModelEntity : "{732A335C72D8ADE2}Prefabs/Props/Military/Sandbags/Sandbag_0
  coords 4345.621 22.309 3926.781
  angles 0 -47.861 0
 }
-GenericEntity : "{937999008F178E82}Prefabs/Props/Military/Sandbags/Sandbag_01_short_high_burlap.et" {
- components {
-  TILW_NavmeshRegenComponent "{69E6C5F252475CE4}" {
+GenericEntity : "{8A5EFCA9A0C98AFC}Prefabs/Models/props/tem_pillow1.et" {
+ coords 4339.036 21.204 3895.616
+ angles 0 -36.877 0
+}
+GenericEntity : "{8FCA78A788DF338C}Prefabs/Structures/Misc/pillow1.et" {
+ coords 4340.65 21.364 3894.601
+ angles 0 0 -43.779
+}
+$grp GenericEntity : "{937999008F178E82}Prefabs/Props/Military/Sandbags/Sandbag_01_short_high_burlap.et" {
+ {
+  components {
+   TILW_NavmeshRegenComponent "{69E6C5F252475CE4}" {
+   }
   }
+  coords 4339.573 20.968 3917.999
+  angles 0 -46.879 0
  }
- coords 4339.573 20.968 3917.999
- angles 0 -46.879 0
+ {
+  components {
+   TILW_NavmeshRegenComponent "{69F6F348B19E2E48}" {
+   }
+  }
+  coords 4318.671 21.159 3901.116
+  angles 0 42.824 0
+ }
+ {
+  components {
+   TILW_NavmeshRegenComponent "{69F6F348A93F64A3}" {
+   }
+  }
+  coords 4323.161 21.062 3905.96
+  angles 0 41.825 0
+ }
 }
 $grp GenericEntity : "{9C9C4BED9E19C374}Prefabs/Props/Military/Sandbags/Sandbag_01_wall_solid_burlap.et" {
  {
@@ -538,6 +580,30 @@ $grp GenericEntity : "{B547CF929FCC6BB7}Prefabs/Props/Military/Sandbags/Sandbag_
   coords 4337.494 27.567 3886.587
   angles 0.008 -48.049 -0.697
  }
+ {
+  components {
+   TILW_NavmeshRegenComponent "{69F6F348B271B7F1}" {
+   }
+  }
+  coords 4319.914 21.136 3899.981
+  angles 0 43.873 0
+ }
+ {
+  components {
+   TILW_NavmeshRegenComponent "{69F6F348AA456027}" {
+   }
+  }
+  coords 4324.423 21.07 3904.847
+  angles 0 42.875 0
+ }
+ {
+  components {
+   TILW_NavmeshRegenComponent "{69F6F348B70347C8}" {
+   }
+  }
+  coords 4321.756 21.108 3903.424
+  angles 0 41.162 0
+ }
 }
 StaticModelEntity : "{B9BD7523E6370435}Prefabs/Structures/BuildingParts/Entry/ConcreteStairs_03_narrow_v2.et" {
  components {
@@ -546,6 +612,10 @@ StaticModelEntity : "{B9BD7523E6370435}Prefabs/Structures/BuildingParts/Entry/Co
  }
  coords 4338.127 21.366 3921.829
  angles 0 131.302 0
+}
+GenericEntity : "{BA388E12A76B90E9}Prefabs/Models/props/tem_carpet3.et" {
+ coords 4337.271 21.199 3894.282
+ angles 0 0 0
 }
 $grp GenericEntity : "{BE16EE8FAA315FE2}Prefabs/Props/Military/Sandbags/Sandbag_01_long_high_burlap.et" {
  {
@@ -607,6 +677,14 @@ $grp GenericEntity : "{BE16EE8FAA315FE2}Prefabs/Props/Military/Sandbags/Sandbag_
   }
   coords 4356.142 21.164 3919.237
   angles 0 -137.821 0
+ }
+ {
+  components {
+   TILW_NavmeshRegenComponent "{69F6F348B5B696A7}" {
+   }
+  }
+  coords 4321.615 21.087 3904.973
+  angles 0 -48.065 0
  }
 }
 $grp GenericEntity : "{C7A49C5B54C86903}Prefabs/Props/Military/Sandbags/Sandbag_01_single_burlap.et" {
@@ -1268,6 +1346,27 @@ $grp GenericEntity : "{C7A49C5B54C86903}Prefabs/Props/Military/Sandbags/Sandbag_
 GenericEntity : "{C7DA8607C3B3057E}Prefabs/Compositions/Misc/FreeRoamBuilding/SandbagWallBurlap_S_USSR_01.et" {
  coords 4319.445 17.844 3894.913
  angles 0 42.978 0
+}
+$grp GenericEntity : "{CC5453CCC311603B}Prefabs/Props/Military/Sandbags/Sandbag_01_end_burlap.et" {
+ {
+  components {
+   TILW_NavmeshRegenComponent "{69F6F348BF777EAD}" {
+   }
+  }
+  coords 4320.801 21.131 3899.114
+  angles 0 41.992 0
+ }
+ {
+  components {
+   TILW_NavmeshRegenComponent "{69F6F348A89E485D}" {
+   }
+  }
+  coords 4325.326 21.072 3903.995
+  angles 0 40.993 0
+ }
+}
+GenericEntity : "{E39E4C47341BBCA2}Prefabs/Structures/Misc/pillow2.et" {
+ coords 4337.776 21.204 3894.206
 }
 $grp StaticModelEntity : "{EF39F5715EF2323E}Prefabs/Structures/Walls/BarbedWire/BarbedTape_01/BarbedTape_01_Short.et" {
  {

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/PROPS/CimicHouses/LooseProps.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/PROPS/CimicHouses/LooseProps.layer
@@ -172,6 +172,28 @@ GenericEntity : "{52A12ECB132C3E1F}Prefabs/Props/Furniture/TableKitchen_02/Table
  coords 4346.902 18.024 3891.669
  angles 0 69.965 0
 }
+GameEntity : "{5345F558B02B8A91}Prefabs/Structures/BuildingParts/Ladders/Ladder_Powerline_HV_USSR_01/Ladder_Powerline_HV_USSR_01_end_v3_base.et" {
+ components {
+  TILW_NavmeshRegenComponent "{69F6F348454DFFB1}" {
+  }
+  ActionsManagerComponent "{5916A63C9331DAB0}" {
+   ActionContexts {
+    UserActionContext "{5916A63C9D2ABA4A}" {
+     Position PointInfo "{5916A63C9B51DDAE}" {
+      Offset 0.0087 0.4935 -0.0033
+     }
+    }
+    UserActionContext "{5916A63C9CED0D8A}" {
+     Position PointInfo "{5916A63CE468E545}" {
+      Offset -0.0062 -1.9445 0.0003
+     }
+    }
+   }
+  }
+ }
+ coords 4325.25 3.27 3902.47
+ angles 0 129.932 -1.021
+}
 GenericEntity : "{5D12784AFD6B64B2}Prefabs/Props/Furniture/CabinetMetal_02_Base.et" {
  components {
   TILW_NavmeshRegenComponent "{69ECF1DC750BFD45}" {

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/PROPS/OuterProps.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/PROPS/OuterProps.layer
@@ -14,6 +14,14 @@ SCR_DestructibleBuildingEntity : "{11298B17EF8881E1}Prefabs/Structures/Houses/Vi
  coords 4502.042 0 4060.803
  angles 0 53.82 0
 }
+SCR_DestructibleBuildingEntity : "{1350F724723AAC87}Prefabs/Structures/Industrial/Houses/Warehouse_01/Warehouse_01_V3.et" {
+ components {
+  TILW_NavmeshRegenComponent "{69F6F34CB79F550F}" {
+  }
+ }
+ coords 4042.583 0 3715.723
+ angles 0 52.776 0
+}
 SCR_DestructibleBuildingEntity : "{157F48572474AE44}Prefarbs/USE_THIS_New_buildings/House_12_WinDoor.et" {
  components {
   TILW_NavmeshRegenComponent "{69EAF800F6019F4C}" {
@@ -21,6 +29,14 @@ SCR_DestructibleBuildingEntity : "{157F48572474AE44}Prefarbs/USE_THIS_New_buildi
  }
  coords 4492.131 0 4075.643
  angles 0 -38.238 0
+}
+GenericEntity : "{17141C691DCD56C1}Prefabs/Structures/Wreck/bluecar1.et" {
+ components {
+  TILW_NavmeshRegenComponent "{69F6F34EE24BC153}" {
+  }
+ }
+ coords 4308.249 17.726 3985.366
+ angles 0 0.945 0
 }
 SCR_DestructibleBuildingEntity : "{24BA2E136E8815C2}Prefabs/Structures/Houses/Shed/Shed_02/Shed_02_line.et" {
  components {
@@ -38,6 +54,30 @@ SCR_DestructibleBuildingEntity : "{3616A2E04BAC6D2C}Prefarbs/USE_THIS_New_buildi
  coords 4604.967 0.111 3954.616
  angles 0 42.266 0
 }
+GenericEntity : "{4438254EAEDBB967}Prefabs/Props/Agriculture/Hay Pile Large.et" {
+ components {
+  TILW_NavmeshRegenComponent "{69F6F348F43C0AB9}" {
+  }
+ }
+ coords 4477.13 16.815 3937.409
+ angles 0 -101.686 0
+}
+SCR_DestructibleBuildingEntity : "{8C4772CE0A797A15}Prefarbs/USE_THIS_New_buildings/Construction_01_WinDoor.et" {
+ components {
+  TILW_NavmeshRegenComponent "{69F6F34F1EAF82F7}" {
+  }
+ }
+ coords 4201.567 0.398 3826.323
+ angles 0 -48.867 0
+}
+GenericEntity : "{8FC98E36187E9DFA}Prefabs/Structures/Market/market_tent_1.et" {
+ components {
+  TILW_NavmeshRegenComponent "{69F6F349AA678BE3}" {
+  }
+ }
+ coords 4302.312 17.844 3996.656
+ angles 0 50.087 0
+}
 SCR_DestructibleBuildingEntity : "{B56CBC1D463F9A16}Prefarbs/USE_THIS_New_buildings/Shed_01_WinDoor.et" {
  components {
   TILW_NavmeshRegenComponent "{69EAF80104DA9708}" {
@@ -46,6 +86,32 @@ SCR_DestructibleBuildingEntity : "{B56CBC1D463F9A16}Prefarbs/USE_THIS_New_buildi
  coords 4501.794 0 3768.079
  angles 0 130.163 0
 }
+SCR_DestructibleBuildingEntity : "{BFAF4131777CD7ED}Prefarbs/USE_THIS_New_buildings/Garage_apartment_02_WinDoor.et" {
+ components {
+  TILW_NavmeshRegenComponent "{69EF09730E2CA042}" {
+  }
+ }
+ coords 4178.195 0 3751.377
+ angles 0 77.118 0
+}
+$grp GenericEntity : "{C9CFDED29542A968}Prefabs/Props/Military/Furniture/CotMilitary_US_01.et" {
+ {
+  coords 4362.771 21.724 3897.819
+  angles 0 131.488 0
+ }
+ {
+  coords 4358.182 21.724 3897.278
+  angles 0 43.609 0
+ }
+ {
+  coords 4360.945 21.724 3893.804
+  angles 0 -48.076 0
+ }
+ {
+  coords 4363.508 21.724 3891.603
+  angles 0 -48.531 0
+ }
+}
 SCR_DestructibleBuildingEntity : "{EC7E166DAC213EBA}Prefabs/Infrastructure/Bus/Bussheds/Bus Shed 02.et" {
  components {
   TILW_NavmeshRegenComponent "{69EAF822071D3071}" {
@@ -53,6 +119,10 @@ SCR_DestructibleBuildingEntity : "{EC7E166DAC213EBA}Prefabs/Infrastructure/Bus/B
  }
  coords 4528.565 0 4080.354
  angles 0 51.067 0
+}
+SCR_DestructibleBuildingEntity : "{F4DD82E42B98C74C}Prefabs/Structures/Bulding/Construction/A_CraneCon.et" {
+ coords 4197.811 19.142 3883.573
+ angles 0 36.776 0
 }
 SCR_DestructibleBuildingEntity : "{FCB23B78667B59BE}Prefarbs/USE_THIS_New_buildings/Garage_01_WinDoor.et" {
  components {

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllBriefs.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllBriefs.layer
@@ -7,6 +7,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "Can the garrison hold long enough to force the attackers to withdraw?"\
   ""\
   "<h2>Summary Notes</h2>"\
+  "• E-tool usage is strictly forbidden."\
   "• Iraqi forces only to be slotted if missions is <b>FULL</b> or if blufor accept the challenge."\
   "• The mission is <b>LIVE</b> from the moment you enter the game."
   m_bEmptyFactionVisibility 1
@@ -31,12 +32,32 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "• Overrun the British garrison by eliminating at least 85% (26/30) of British forces and occupy the compound."\
   ""\
   "<h2>Mission Notes</h2>"\
-  "• JIP TP"\
+  "• E-tool usage is strictly forbidden."\
   "• Iraqi forces only to be slotted if missions is <b>FULL</b> or if blufor accept the challenge."\
+  "• JIP TP."\
+  "• UK AO limit."\
   ""\
   "Mission made by TheLocalPub. Please use the <b>#feedback</b> channel on Discord to report issues or submit suggestions."
   m_bEmptyFactionVisibility 1
   m_bShowForAnyFaction 1
   m_iOrder 10
+ }
+ CL {
+  coords 7070.548 152.503 742.933
+  m_sTitle "Mission notes"
+  m_sTextData "<h2>Added:</h2>"\
+  "• More buildings around the outside of the compound and their respective markers."\
+  "• Further low/small cover to the area outside the compound to make the AI not a total turket shoot at times."\
+  "• Further fortifications to the compound, including a ladder to the garage roof with fighting positons."\
+  "• UK AO limit to brief."\
+  "• MMG Markers"\
+  ""\
+  "<h2>Changed:</h2>"\
+  "• AI settings - They should now be more aggressive, faster to the compound, and also better at engaging from a distance."\
+  "• AI numbers - Increased by 10 units a wave."\
+  "• AI placement - Moved some groups to different areas to try spread out their direction of travel."
+  m_bEmptyFactionVisibility 1
+  m_bShowForAnyFaction 1
+  m_iOrder 11
  }
 }

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllBriefs.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllBriefs.layer
@@ -47,8 +47,8 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTitle "Changelog"
   m_sTextData "<h2>Added:</h2>"\
   "• More buildings around the outside of the compound and their respective markers."\
-  "• Further low/small cover to the area outside the compound to make the AI not a total turket shoot at times."\
-  "• Further fortifications to the compound, including a ladder to the garage roof with fighting positons."\
+  "• Further low/small cover to the area outside the compound to make the AI not a total turkey shoot at times."\
+  "• Further fortifications to the compound, including a ladder to the garage roof with fighting positions."\
   "• UK AO limit to brief."\
   "• MMG Markers"\
   ""\

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllBriefs.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllBriefs.layer
@@ -44,7 +44,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
  }
  CL {
   coords 7070.548 152.503 742.933
-  m_sTitle "Mission notes"
+  m_sTitle "Changelog"
   m_sTextData "<h2>Added:</h2>"\
   "• More buildings around the outside of the compound and their respective markers."\
   "• Further low/small cover to the area outside the compound to make the AI not a total turket shoot at times."\

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllMarkers.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllMarkers.layer
@@ -151,14 +151,78 @@ $grp PolylineShapeEntity : "{A0468F86F76FCEE7}Prefabs/Logic/Map/TILW_MapShape.et
    }
   }
  }
-}
-SCR_DestructibleBuildingEntity : "{BFAF4131777CD7ED}Prefarbs/USE_THIS_New_buildings/Garage_apartment_02_WinDoor.et" {
- components {
-  TILW_NavmeshRegenComponent "{69EF09730E2CA042}" {
+ Building6 {
+  components {
+   TILW_MapShapeComponent "{6508F5526836BC09}" {
+    m_color 0.423 0.423 0.423 0.75
+    m_drawLine 1
+    m_lineColor 0.205 0.205 0.205 1
+    m_lineWidth 1
+   }
+  }
+  coords 1269.063 36.527 853.674
+  Points {
+   ShapePoint "{69F6F34F326FF6E2}" {
+    Position 2789.13 -18.683 2852.783
+   }
+   ShapePoint "{69F6F34F3337236D}" {
+    Position 2766.744 -18.683 2882.732
+   }
+   ShapePoint "{69F6F34F3030B7CE}" {
+    Position 2755.545 -18.683 2874.583
+   }
+   ShapePoint "{69F6F34F31D6ABB8}" {
+    Position 2777.633 -18.683 2844.448
+   }
   }
  }
- coords 4178.195 0 3751.377
- angles 0 77.118 0
+ Building7 {
+  components {
+   TILW_MapShapeComponent "{6508F5526836BC09}" {
+    m_color 0.423 0.423 0.423 0.75
+    m_drawLine 1
+    m_lineColor 0.205 0.205 0.205 1
+    m_lineWidth 1
+   }
+  }
+  coords 1734.337 17.89 1903.051
+  Points {
+   ShapePoint "{69F6F34F7D02C9A9}" {
+    Position 2505.429 -0.046 1966.732
+   }
+   ShapePoint "{69F6F34F72139C91}" {
+    Position 2480.341 -0.046 1989.17
+   }
+   ShapePoint "{69F6F34F713084A5}" {
+    Position 2444.664 0.464 1948.624
+   }
+  }
+ }
+ Building8 {
+  components {
+   TILW_MapShapeComponent "{6508F5526836BC09}" {
+    m_color 0.423 0.423 0.423 0.75
+    m_drawLine 1
+    m_lineColor 0.205 0.205 0.205 1
+    m_lineWidth 1
+   }
+  }
+  coords 1734.337 17.89 1903.051
+  Points {
+   ShapePoint "{69F6F34F7D02C9A9}" {
+    Position 2505.429 -0.046 1966.732
+   }
+   ShapePoint "{69F6F34F72139C91}" {
+    Position 2480.341 -0.046 1989.17
+   }
+   ShapePoint "{69F6F34F713084A5}" {
+    Position 2444.664 0.464 1948.624
+   }
+   ShapePoint "{69F6F34F74AB28D9}" {
+    Position 2469.607 -0.046 1926.018
+   }
+  }
+ }
 }
 $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker.et" {
  BluforSpawn {
@@ -304,6 +368,54 @@ $grp PS_ManualMarker : "{CD85ADE9E0F54679}PrefabsEditable/Markers/EditableMarker
    CUTSCENE
    DEBRIEFING
    BRIEFING
+  }
+  m_bShowForAnyFaction 1
+ }
+ MMG1 {
+  coords 4346.582 22.448 3925.082
+  angles 0 45.164 0
+  m_sImageSet "{83B695FF662AC163}imagesets/Soviet_Tactical_Graphics.imageset"
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mmg"
+  m_fWorldSize 10
+  m_sDescription "GPMG"
+  m_bVisibleForEmptyFaction 1
+  m_aHideOnGameModeStates {
+   PREGAME
+   PREGAME
+  }
+  m_bShowForAnyFaction 1
+ }
+ MMG3 {
+  coords 4345.176 26.844 3875.283
+  angles 0 -134.836 0
+  m_sImageSet "{83B695FF662AC163}imagesets/Soviet_Tactical_Graphics.imageset"
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mmg"
+  m_fWorldSize 10
+  m_sDescription "GPMG"
+  m_bVisibleForEmptyFaction 1
+  m_aHideOnGameModeStates {
+   PREGAME
+   PREGAME
+  }
+  m_bShowForAnyFaction 1
+ }
+ MMG2 {
+  coords 4368.251 27.503 3901.484
+  angles 0 135.164 0
+  m_sImageSet "{83B695FF662AC163}imagesets/Soviet_Tactical_Graphics.imageset"
+  m_sImageSetGlow ""
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mmg"
+  m_fWorldSize 10
+  m_sDescription "GPMG"
+  m_bVisibleForEmptyFaction 1
+  m_aHideOnGameModeStates {
+   PREGAME
+   PREGAME
   }
   m_bShowForAnyFaction 1
  }

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/default.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/default.layer
@@ -30,6 +30,8 @@ PS_GameModeCoop PS_GameMode_Lobby_GC1 : "{4CFD54745CD45673}Prefabs/MP/Modes/PS_G
   }
  }
  coords 6692.722 53.557 3608.832
+ m_fPrepMultiplier 1000
+ m_fGameMultiplier 1000
 }
 TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramework.et" {
  coords 6693.593 65.693 3356.336


### PR DESCRIPTION
# Changelog
## Added:
• More buildings around the outside of the compound and their respective markers.
• Further low/small cover to the area outside the compound to make the AI not a total turkey shoot at times.
• Further fortifications to the compound, including a ladder to the garage roof with fighting positions.
• UK AO limit to brief.
• MMG Markers

## Changed:
• AI settings - They should now be more aggressive, faster to the compound, and also better at engaging from a distance.
• AI numbers - Increased by 10 units a wave.
• AI placement - Moved some groups to different areas to try spread out their direction of travel.