### PR TITLE
CleanHouse Update

### DIFF
--- a/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/BLUFOR/Briefs.layer
+++ b/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/BLUFOR/Briefs.layer
@@ -29,11 +29,10 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "The apartment building is a large complex consisting of 5 floors and a rooftop. With roughly 50 meters of frontage along it's largest sides."\
   "Fortifed with dug-in fighting positions and good 360 degree sightlines."\
   ""\
-  "<h2>STRENGTHS & CAPABILITIES</h2> "\
-  "• The enemy is completely isolated and cut off from reinforcements and external support."\
-  "• They are assessed to have limited capabilities, low morale, and dwindling supplies."\
-  "• However, fighters with no avenue of escape can become highly determined and unpredictable. Expect them to exploit every available advantage, even at significant cost, and to resist fiercely despite their situation."\
-  "• There is a PKM turret on the 3rd floor west facing balcony."
+  "<h2>STRENGTHS & CAPABILITIES</h2>"\
+  "• There is a PKM turret on the 3rd floor west facing balcony."\
+  "• The enemy is completely isolated and cut off from reinforcements and external support. They are assessed to have limited capabilities, low morale, and dwindling supplies."\
+  "• However, fighters with no avenue of escape can become highly determined and unpredictable. Expect them to exploit every available advantage, even at significant cost, and to resist fiercely despite their situation."
   m_aVisibleForFactions {
    "RHS_AFRF"
   }
@@ -47,18 +46,14 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "We are currently located at the staging area, preparing to step off toward the designated insertion points."\
   ""\
   "After the setup timer has ended, we may deploy to any designated insertion location via the doors at the staging area."\
-  "At the staging area, a mock-up model of the target building is available. This allows us to study the layout, plan our approach, and rehearse entry methods - including ladder placement and other breaching techniques prior to execution."\
+  "A mock-up model of the target building is available where we start."\
   ""\
   "<h2>STRENGTHS & CAPABILITIES</h2> "\
-  "• We have total freedom of movement within the city. All other organized enemy resistance has been neutralized."\
-  "• We are able to take the time required to properly position, coordinate, and prepare for the assault without concern for external interference."\
+  "• We have total freedom of movement within the city. All other organized enemy resistance has been neutralized, which gives us the  time required to properly position, coordinate, and prepare for the assault without external interference."\
   " "\
   "<h2>SERVICE & SUPPORT</h2> "\
   "A supply crate is available at the staging location containing:"\
-  "• 8x deployable ladders"\
-  "• 16x demolition charges"\
-  "• 8x clackers (detonators)"\
-  "• 10x wire cutters"
+  "• 8x deployable ladders"
   m_aVisibleForFactions {
    "RHS_AFRF"
   }

--- a/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/OFPOR/Briefs.layer
+++ b/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/OFPOR/Briefs.layer
@@ -50,8 +50,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   ""\
   "<h2>STRENGTHS & CAPABILITIES</h2> "\
   "• The enemy has total freedom of movement within the city. With no remaining resistance outside this position, they can take their time to plan, coordinate, and prepare their assault without fear of disruption."\
-  "• They are able to establish overwatch positions, including sniper teams and support elements, in surrounding buildings and maintain sustained pressure over time, gradually degrading our defenses."\
-  "• They may plan to destroy the whole building through demolitions."
+  "• They are able to establish overwatch positions, including sniper teams and support elements, in surrounding buildings and maintain sustained pressure over time, gradually degrading our defenses."
   m_aVisibleForFactions {
    "GC_SEPARATIST"
   }

--- a/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/PROPS/BluforSpawn.layer
+++ b/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/PROPS/BluforSpawn.layer
@@ -59,7 +59,7 @@ GenericEntity RedDoor : "{9EB592E7C7CD1C0F}Prefabs/Structures/BuildingParts/Door
   }
  }
 }
-$grp GenericEntity : "{AC0BE9625BFD0470}Prefabs/Models/ind/tem_ind_canalwall1.et" {
+$grp SCR_DestructibleBuildingEntity : "{AC0BE9625BFD0470}Prefabs/Models/ind/tem_ind_canalwall1.et" {
  {
   coords 7812.163 159.303 5450.632
  }
@@ -110,24 +110,6 @@ GenericEntity EquipmentBox : "{C2D5FBC0BB90544A}PrefabsEditable/Auto/Props/Milit
      }
      NumSlots 8
     }
-    MultiSlotConfiguration "{68B2F38933D8408F}" {
-     SlotTemplate EquipmentStorageSlot Charges {
-      Prefab "{97064F8597F2D7BF}Prefabs/Weapons/Explosives/DemoBlock_TSh400g/DemoBlock_TSh400g.et"
-     }
-     NumSlots 16
-    }
-    MultiSlotConfiguration "{68B2F3892DC34F2B}" {
-     SlotTemplate EquipmentStorageSlot clacker {
-      Prefab "{90976DC90A223095}Prefabs/Items/Equipment/Detonators/BlastingMachine_KPM_3U1/BlastingMachine_KPM_3U1.et"
-     }
-     NumSlots 8
-    }
-    MultiSlotConfiguration "{68B2F380888BB332}" {
-     SlotTemplate EquipmentStorageSlot Wirecutters {
-      Prefab "{42232FFE6E7AC415}Prefabs/Items/Core/Wirecutters/wirecutters.et"
-     }
-     NumSlots 10
-    }
    }
   }
   ActionsManagerComponent "{5476B36C403D4CC0}" {
@@ -141,7 +123,7 @@ GenericEntity EquipmentBox : "{C2D5FBC0BB90544A}PrefabsEditable/Auto/Props/Milit
    }
   }
  }
- coords 10669.535 164.152 9554.237
+ coords 7914.476 164.149 5342.942
 }
 GenericEntity : "{C5E5467213DB03DA}PrefabsEditable/Auto/EffectsModuleEntities/E_EffectModule_DirectionArrow_Multiple.et" {
  coords 7892.21 168 5341.875

--- a/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/PROPS/TownArea.layer
+++ b/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/PROPS/TownArea.layer
@@ -2500,7 +2500,7 @@ GenericEntity : "{32DE30B02A04B844}Prefabs/Compositions/Misc/SubCompositions/For
  coords 11881.897 8.287 10603.948
  angles 0 165.826 0
 }
-SCR_DestructibleEntity : "{33788AFA51F4A4EC}Prefabs/Models/tem_bike2_red.et" {
+GenericEntity : "{33788AFA51F4A4EC}Prefabs/Models/tem_bike2_red.et" {
  components {
   PK_EntityProtectorComponent "{68B4C8C4F8F5D473}" {
   }
@@ -6984,7 +6984,7 @@ GenericEntity : "{8F05D427252644F8}Prefabs/Props/Civilian/Suitcase_01.et" {
  coords 11808.287 12.688 10643.407
  angles 88.612 0 0
 }
-SCR_DestructibleEntity : "{8F3C2CE67D6501A8}Prefabs/Models/tem_bike1.et" {
+GenericEntity : "{8F3C2CE67D6501A8}Prefabs/Models/tem_bike1.et" {
  components {
   PK_EntityProtectorComponent "{68B4C8C77052911C}" {
   }
@@ -6996,7 +6996,7 @@ StaticModelEntity : "{90083B2935EF911B}Prefabs/Models/tem_datsun_wreck.et" {
  coords 11988.001 3.967 10679.558
  angles 0 0 -101.937
 }
-SCR_DestructibleEntity : "{90180A1F8AED476F}Prefabs/Models/tem_tractor_open.et" {
+GenericEntity : "{90180A1F8AED476F}Prefabs/Models/tem_tractor_open.et" {
  coords 12006.889 -0.011 10699.113
  angles 0 -121.424 0
 }
@@ -8747,7 +8747,7 @@ $grp StaticModelEntity : "{A46D45922F8CAD6C}Prefabs/Props/Military/Fortification
   angles -3.143 37.93 5.468
  }
  {
-  coords 11839.713 -0 10642.33
+  coords 11839.713 0 10642.33
   angles -6.676 68.633 7.339
  }
  {
@@ -9230,7 +9230,7 @@ $grp StaticModelEntity : "{AE28D47CF26E91EA}Prefabs/Props/Military/Fortification
   angles -2.684 0 2.681
  }
  {
-  coords 11905.32 -0 10665.688
+  coords 11905.32 0 10665.688
   angles -2.684 0 6.235
  }
  {
@@ -9262,7 +9262,7 @@ $grp StaticModelEntity : "{AE28D47CF26E91EA}Prefabs/Props/Military/Fortification
   angles 4.467 0 0
  }
  {
-  coords 11910.254 -0 10668.531
+  coords 11910.254 0 10668.531
   angles -1.79 0 4.465
  }
  {

--- a/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/SYSTEMS/Deleters.layer
+++ b/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/SYSTEMS/Deleters.layer
@@ -3,21 +3,25 @@ $grp PK_EntityDeleter {
   coords 11786.605 24.304 10616.996
   angles 0 -15.934 0
   m_fRadius 16
+  m_bByParentOnly 0
  }
  {
   coords 11783.415 24.304 10628.174
   angles 0 -15.934 0
   m_fRadius 16
+  m_bByParentOnly 0
  }
  {
   coords 11779.688 24.304 10641.231
   angles 0 -15.934 0
   m_fRadius 16
+  m_bByParentOnly 0
  }
  {
   coords 11771.086 24.304 10665.619
   angles 0 -15.934 0
   m_fRadius 19
+  m_bByParentOnly 0
  }
  {
   coords 12084.209 2.781 10824.541
@@ -32,5 +36,6 @@ $grp PK_EntityDeleter {
   coords 7908.004 167.862 5391.076
   angles 0 -15.934 0
   m_fRadius 35
+  m_bByParentOnly 0
  }
 }

--- a/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/default.layer
+++ b/worlds/TheLocalPub/CleanHouse/CleanHouse_Layers/default.layer
@@ -22,7 +22,7 @@ PS_GameModeCoop PS_GameMode_Lobby_GC1 : "{4CFD54745CD45673}Prefabs/MP/Modes/PS_G
   }
  }
  coords 13294.985 0 9615.088
- m_iFreezeTime 240000
+ m_iFreezeTime 120000
  m_eJIPState Deny
 }
 TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramework.et" {
@@ -32,11 +32,11 @@ TILW_MissionFrameworkEntity : "{8F846D0FD5D6EA51}Prefabs/MP/TILW_MissionFramewor
    m_name "SetupTimer"
    m_instructions {
     TILW_SetFlagInstruction "{68B2F38D12C79402}" {
-     m_executionDelay 240
+     m_executionDelay 120
      m_flagName "SetupFinished"
     }
     TILW_SendMessageInstruction "{68B2F3804A907139}" {
-     m_executionDelay 240
+     m_executionDelay 120
      m_messageTitle "Teleports activated"
      m_messageBody "You can now teleport to the insert locations via the coloured doors"
      m_factionKeys {


### PR DESCRIPTION
# Changelog
## Fixed:
- Equipment box for the Russians wasn't in the spawn area
- PK deleter now works correctly again meaning the target building and area should display intended (Since the last time it was updated, It appears it needed to be adjusted to work accordingly)

## Adjusted:
- Briefing to trim abit of fat
- Setup timer reduced from 4>2mins.

## Removed:
- Some equipment from the Russian supply crate such as the useless wire-cutters and demo charges.