### PR TITLE
Public enemies update

### DIFF
--- a/Missions/TheLocalPub/PublicEnemies.conf
+++ b/Missions/TheLocalPub/PublicEnemies.conf
@@ -1,8 +1,8 @@
 SCR_MissionHeader {
  World "{F4E75BA1BAF46F2E}worlds/TheLocalPub/PublicEnemies/PublicEnemies.ent"
- m_sName "TVT (10-48) Public Enemies"
+ m_sName "TVT (10-46) Public Enemies"
  m_sAuthor "TheLocalPub"
  m_sDescription "Two rivals gangs have arranged a meeting to negotiate peace after years of war. But for corrupt federal officers, they seek to keep the mobs warring for their own gain."
  m_sDetails "Two rivals gangs have arranged a meeting to negotiate peace after years of war. But for corrupt federal officers, they seek to keep the mobs warring for their own gain."
- m_iPlayerCount 48
+ m_iPlayerCount 46
 }

--- a/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/BLUFOR/Briefs.layer
+++ b/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/BLUFOR/Briefs.layer
@@ -3,7 +3,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   coords 28.634 78.196 2605.741
   m_sTitle "Situation"
   m_sTextData "<h2>PRELIMS</h2>"\
-  "DTL: 22/07/1945, 2000hr, Manitowish Waters, Wisconsin"\
+  "DTL: 22/03/1945, 2200hr, Manitowish Waters, Wisconsin"\
   "Weather: Clear and dry with no forecast of change. Sightlines 1km+"\
   "Terrain: Multiple shallow fords located throughout the river marked with yellow, patchey open fields tyically with deep running ditches alongside and dense woodblock with scattered treelines, many dotted hamlets and towns throughout."\
   ""\

--- a/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/BLUFOR/Briefs.layer
+++ b/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/BLUFOR/Briefs.layer
@@ -22,17 +22,11 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   coords 28.634 78.196 2605.741
   m_sTitle "Enemy forces"
   m_sTextData "<h2>Composition & Disposition</h2>"\
-  ""\
-  "<b>Composition</b>"\
-  "Enemy forces consist of two established organized crime groups known as the Brown Suited Bashers and the Grey Suited Grapplers. Both outfits are well-financed, motivated, and structured criminal enterprises with influence across multiple cities within the United States."\
-  "An informant provided intelligence via a dead drop, indicating approximately 20 personnel are present at the meeting location, with no civilians in attendance."\
-  ""\
-  "<b>Disposition</b>"\
-  "Both organizations are scheduled to meet at Little Bohemian Lodge (GRID: 027010), a secluded and defensible hamlet. The location offers controlled access points, natural cover, and is flanked by a river, making it well suited for security and defensive operations."\
+  "Enemy forces consist of two organised crime groups, the Brown Suited Bashers and Grey Suited Grapplers. Both are well-financed, motivated, and structured criminal enterprises with influence across multiple US cities. "\
+  "Intelligence obtained through an informant's dead drop indicates approximately 20 personnel are expected at the meeting location, with no civilians present. Both groups are scheduled to meet at Little Bohemian Lodge (GRID: 027010), a secluded and defensible hamlet with controlled access points, natural cover, and a river flanking the area."\
   ""\
   "<h2>Strengths & Capabilities</h2>"\
   "• Our informant reports that both mobs are well armed, carrying a range of weapons including automatic submachine guns, semi-automatic rifles, shotguns, handguns, and improvised firebombs.  "\
-  "• They arrived in standard civilian vehicles, which are neither armed nor up-armoured.  "\
   "• Little Bohemian Lodge offers strong defensive potential, with high hedgerows, perimeter fencing, a flanking river, and elevated structures providing concealment, cover, and advantageous fields of fire, making it well suited for close-in defense.  "\
   ""\
   "<b>MLCO:</b> The mobs are expected to deploy sentries and conduct patrols around the compound while maintaining security and awaiting contact.  "\
@@ -59,8 +53,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "<h2>Strengths & Capabilities</h2>"\
   "• Each insert location provides 7 unarmed civilian vehicles. The southern insert also includes 2 boats positioned on the river.  "\
   "- There is a ford between us and the objective. We can cross this with the boats if we go full speed over it. No damage taken."\
-  "• We have full freedom of movement. No other hostile elements are present in the area, and the surrounding terrain is civilian in nature, aside from the lodge itself.  "\
-  "• Personnel are equipped with automatic submachine guns, semi-automatic rifles, shotguns, and handguns."
+  "• We have full freedom of movement. No other hostile elements are present in the area, and the surrounding terrain is civilian in nature, aside from the lodge itself.  "
   m_aVisibleForFactions {
    "GC_Federal"
   }

--- a/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/OPFOR/Briefs.layer
+++ b/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/OPFOR/Briefs.layer
@@ -3,7 +3,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   coords 35.415 79.481 2580.68
   m_sTitle "Situation"
   m_sTextData "<h2>PRELIMS</h2>"\
-  "DTL: 22/07/1945, 2000hr, Manitowish Waters, Wisconsin"\
+  "DTL: 22/03/1945, 2200hr, Manitowish Waters, Wisconsin"\
   "Weather: Clear and dry with no forecast of change. Sightlines 1km+"\
   "Terrain: Multiple shallow fords located throughout the river marked with yellow, patchey open fields tyically with deep running ditches alongside and dense woodblock with scattered treelines, many dotted hamlets and towns throughout."\
   ""\

--- a/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/OPFOR/Briefs.layer
+++ b/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/OPFOR/Briefs.layer
@@ -36,8 +36,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTextData "<h2>Composition & Disposition</h2>"\
   "Unknown."\
   ""\
-  "Although this is a high-profile meeting, it has been kept quiet and tightly controlled."\
-  "We have no specific intelligence indicating an imminent attack, but we must remain prepared."\
+  "This is a high-profile meeting, it has been kept quiet and tightly controlled. We have no specific intelligence indicating an imminent attack, but we must remain prepared."\
   "Historically, our conflicts have involved the Federal Bureau of Investigation (FBI), U.S. Marshals, local law enforcement, and rival criminal organizations."\
   ""\
   "<b>MLCO:</b> If attacked, the enemy’s most likely course of action would be a rapid, coordinated strike from multiple directions, using superior numbers and timing to thin our ranks and defeat elements in detail."\
@@ -52,14 +51,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   coords 35.415 79.481 2580.68
   m_sTitle "Friendly forces"
   m_sTextData "<h2>Composition & Disposition</h2>"\
-  ""\
-  "<b>Composition</b>"\
-  "We are two rival gangs, the Brown Suited Bashers and the Grey Suited Grapplers, coming together to negotiate peace."\
-  "Our combined strength consists of approximately 20 personnel."\
-  "We arrived at the location in unarmed civilian vehicles."\
-  ""\
-  "<b>Disposition</b>"\
-  "We are located at Little Bohemian Lodge along US Highway 51 (GRID 027010). The site is a secluded and defensible hamlet, offering controlled access points, natural cover, and a flanking river, making it well suited for security and defensive operations."\
+  "We are two rival gangs, the Brown Suited Bashers and Grey Suited Grapplers, meeting to negotiate a peace agreement. Our combined strength consists of approximately 18 personnel, arriving at Little Bohemian Lodge along US Highway 51 (GRID: 027010) in unarmed civilian vehicles. "\
   ""\
   "<h2>Strengths & Capabilities</h2>"\
   "• Little Bohemian Lodge offers strong defensive potential, with high hedgerows, perimeter fencing, a flanking river, and elevated buildings providing advantageous firing positions."

--- a/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/OPFOR/Player.layer
+++ b/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/OPFOR/Player.layer
@@ -8,6 +8,17 @@ SCR_AIGroup : "{1CE33BB24C41F43C}worlds/TheLocalPub/PublicEnemies/Prefabs/AI/Gro
  }
  coords 2770.34 60.776 996.683
  angles 0 28.457 0
+ m_aUnitPrefabSlots {
+  "{FB3DF47EABBAE7CF}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Grey/Character_GreyMobster_Boss.et"
+  "{05F3E37780D84DFA}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Grey/Character_GreyMobster_Mobster.et"
+  "{05F3E37780D84DFA}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Grey/Character_GreyMobster_Mobster.et"
+  "{05F3E37780D84DFA}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Grey/Character_GreyMobster_Mobster.et"
+  "{05F3E37780D84DFA}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Grey/Character_GreyMobster_Mobster.et"
+  "{05F3E37780D84DFA}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Grey/Character_GreyMobster_Mobster.et"
+  "{05F3E37780D84DFA}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Grey/Character_GreyMobster_Mobster.et"
+  "{05F3E37780D84DFA}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Grey/Character_GreyMobster_Mobster.et"
+  "{05F3E37780D84DFA}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Grey/Character_GreyMobster_Mobster.et"
+ }
  m_sCustomNameSet "The Grey Suited Grapplers"
 }
 SCR_AIGroup : "{9115FB4624E4329C}worlds/TheLocalPub/PublicEnemies/Prefabs/AI/Groups/Opfor/Group_Mobster_BrownMobsters1.et" {
@@ -15,7 +26,6 @@ SCR_AIGroup : "{9115FB4624E4329C}worlds/TheLocalPub/PublicEnemies/Prefabs/AI/Gro
  angles 0 25.153 0
  m_aUnitPrefabSlots {
   "{E18FFF2A7564502A}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Brown/Character_BrownMobster_Boss.et"
-  "{63F57EAA017D0AA2}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Brown/Character_BrownMobster_Mobster.et"
   "{63F57EAA017D0AA2}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Brown/Character_BrownMobster_Mobster.et"
   "{63F57EAA017D0AA2}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Brown/Character_BrownMobster_Mobster.et"
   "{63F57EAA017D0AA2}worlds/TheLocalPub/PublicEnemies/Prefabs/Characters/Factions/Opfor/Mobsters/Brown/Character_BrownMobster_Mobster.et"

--- a/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/Props/Lodge.layer
+++ b/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/Props/Lodge.layer
@@ -1111,14 +1111,6 @@ GenericEntity : "{857C0558076EE658}Prefabs/Structures/Wreck/lada_red.et" {
  coords 2767.357 60.174 1001.875
  angles -4.297 -74.789 2.631
 }
-SCR_DestructibleBuildingEntity : "{85D3610D3DC3CBB6}Prefabs/Models/tem_finhouse3_yellow.et" {
- components {
-  PK_EntityProtectorComponent "{68B0E4A53A3EBB44}" {
-  }
- }
- coords 2728.14 -0.026 947.097
- angles 0 102.128 0
-}
 GameEntity : "{862432FB57C1C1B3}Prefabs/Props/Civilian/LampKerosene_01/LampKerosene_01_green.et" {
  coords 2765.716 65.015 1021.136
  angles 0 -68.051 0
@@ -1192,14 +1184,6 @@ GenericEntity : "{9C231B6AC1BD0A26}Prefabs/Props/Civilian/Broom_01.et" {
  coords 2775.054 61.094 1014.944
  angles -10.025 27.854 -4.166
 }
-GenericEntity : "{9F75AE30F166DC47}Prefabs/Models/Building_furniture_finhouse4.et" {
- components {
-  PK_EntityProtectorComponent "{68B0E4A5B8A9CB12}" {
-  }
- }
- coords 2774.624 60.5 1021.128
- angles 0 28.3 0
-}
 GenericEntity : "{9FC8D552DAF9C9A0}Prefabs/Props/Civilian/InkwellDecorative_01/InkwellDecorative_01.et" {
  coords 2766.147 65.015 1020.492
  angles 0 30.684 0
@@ -1221,14 +1205,6 @@ $grp GenericEntity : "{A13BCC98B8C380C7}Prefabs/Compositions/Misc/SubComposition
 GenericEntity : "{A208248B503EF831}Prefabs/Props/Civilian/Cart_01.et" {
  coords 2762.992 61.392 975.779
  angles 49.723 99.326 -4.914
-}
-GenericEntity : "{A2418B08840A5570}Prefabs/Models/Building_furniture_finhouse3.et" {
- components {
-  PK_EntityProtectorComponent "{68B0E4A6E9F0FE3B}" {
-  }
- }
- coords 2728.14 57.318 947.097
- angles 0 102.255 0
 }
 GenericEntity : "{A31E5B2DD8FBA845}Prefabs/Props/Garbage/Generic/LitterInterior_01/Single/LitterInterior_USSR_01_ashtray.et" {
  coords 2778.843 62.265 987.557
@@ -1260,10 +1236,6 @@ GenericEntity : "{B985BC22BF2EDF0D}Prefabs/Props/Civilian/AlarmClock_01/AlarmClo
 GenericEntity : "{BCE07A58672955B9}Prefabs/Props/Civilian/Bucket_01.et" {
  coords 2774.679 60.967 1015.212
 }
-GenericEntity : "{BD1F07D0C32629AF}Prefabs/Structures/Wreck/volha.et" {
- coords 2744.986 58.532 1004.601
- angles -2.745 -97.759 -0.734
-}
 SCR_DestructibleBuildingEntity : "{C25857B8323C8D1C}Prefabs/Structures/Cultural/Fountains/Fountain_01_water_SUFFIX.et" {
  coords 2743.941 0.355 971.661
  angles 0 0 0
@@ -1275,14 +1247,6 @@ GenericEntity : "{C2C1CEA73A4D8779}Prefabs/Props/Civilian/Notebook_01_Stack.et" 
 GenericEntity : "{C4444C5766E5387C}Prefabs/Props/Civilian/Birdhouse_01/Birdhouse_01.et" {
  coords 2752.16 62.277 1001.51
  angles 0 0 0
-}
-SCR_DestructibleBuildingEntity : "{C6258CB925769D10}Prefabs/Models/tem_finhouse4_red.et" {
- components {
-  PK_EntityProtectorComponent "{68B0E4A5BE6B668F}" {
-  }
- }
- coords 2774.624 0 1021.128
- angles 0 28.286 0
 }
 GenericEntity : "{C67A378521482995}Prefabs/Props/Furniture/Rack_03.et" {
  coords 2784.861 60.967 1018.003
@@ -1348,6 +1312,10 @@ GenericEntity : "{E46EF21920C34AD1}Prefabs/Models/kaljakori.et" {
 GenericEntity : "{E56F1B739B9792C4}Prefabs/Props/Civilian/Ashtray_01_Full_green.et" {
  coords 2769.456 65.126 1027.083
  angles 0 0 0
+}
+GenericEntity : "{E9001839B5F2D85E}Prefabs/Structures/Wreck/volha.et" {
+ coords 2744.986 58.532 1004.601
+ angles -2.745 -97.759 -0.734
 }
 GenericEntity : "{EA8D922E189837C2}Prefabs/Props/Civilian/Suitcase_04_open.et" {
  coords 2769.814 64.606 1029.386

--- a/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/Systems/Deleters.layer
+++ b/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/Systems/Deleters.layer
@@ -9,6 +9,7 @@ $grp PK_EntityDeleter {
    "{04A36304123DADEF}PrefabLibrary/DefaultLibrary/Infrastructure/Roads/CrashBarrier_01_8m_V1.et"
    "{68F757E4AEF922C1}PrefabLibrary/DefaultLibrary/Infrastructure/Roads/CrashBarrier_01_8m_V2.et"
   }
+  m_bPreviewShape 0
  }
  {
   coords 2260.896 53.831 397.897
@@ -20,24 +21,48 @@ $grp PK_EntityDeleter {
    "{93335A71CAAC4B7B}Prefabs/Rocks/Granite/Granite_ForestStone_02.et"
    "{FF676E917668C455}Prefabs/Rocks/Granite/Granite_ForestStone_01.et"
    "{76AF1688C649DC10}Prefabs/Rocks/Granite/Granite_ForestStone_03.et"
-   "{C98A6C1C2372354E}Prefabs/Vegetation/Bush/b_corylus_avellana_1_collision.et"
-   "{AF4BFBE29028A9FD}Prefabs/Vegetation/Bush/b_corylus_avellana_1l_collision.et"
+   "{C98A6C1C2372354E}Prefabs/Vegetation/Bush/b_corylus_avellana_1.et"
+   "{AF4BFBE29028A9FD}Prefabs/Vegetation/Bush/b_corylus_avellana_1l.et"
   }
+  m_bPreviewShape 0
  }
  {
   coords 2786.295 62.155 982.228
   m_fRadius 5
   m_prefabFilterList {
-   "{D6EC31A48403A52A}Prefabs/Vegetation/Bush/b_sambucus_nigra_1_collision.et"
-   "{A5DE58FC9FB6BA60}Prefabs/Vegetation/Bush/b_corylus_avellana_2_collision.et"
-   "{C98A6C1C2372354E}Prefabs/Vegetation/Bush/b_corylus_avellana_1_collision.et"
-   "{AF4BFBE29028A9FD}Prefabs/Vegetation/Bush/b_corylus_avellana_1l_collision.et"
-   "{0CA0547EB03759E1}Prefabs/Vegetation/Bush/b_rubus_idaeus_1s_collision.et"
-   "{124518D13290A687}Prefabs/Vegetation/Bush/b_salix_cinerea_0_collision.et"
-   "{23C0BE9D80929DBD}Prefabs/Vegetation/Bush/b_salix_cinerea_1w_collision.et"
-   "{BA785041AC632123}Prefabs/Vegetation/Bush/b_salix_cinerea_1_collision.et"
+   "{D6EC31A48403A52A}Prefabs/Vegetation/Bush/b_sambucus_nigra_1.et"
+   "{A5DE58FC9FB6BA60}Prefabs/Vegetation/Bush/b_corylus_avellana_2.et"
+   "{C98A6C1C2372354E}Prefabs/Vegetation/Bush/b_corylus_avellana_1.et"
+   "{AF4BFBE29028A9FD}Prefabs/Vegetation/Bush/b_corylus_avellana_1l.et"
+   "{0CA0547EB03759E1}Prefabs/Vegetation/Bush/b_rubus_idaeus_1s.et"
+   "{124518D13290A687}Prefabs/Vegetation/Bush/b_salix_cinerea_0.et"
+   "{23C0BE9D80929DBD}Prefabs/Vegetation/Bush/b_salix_cinerea_1w.et"
+   "{BA785041AC632123}Prefabs/Vegetation/Bush/b_salix_cinerea_1.et"
    "{BAB8054438C72A04}Prefabs/Vegetation/Bush/b_sambucus_nigra_2.et"
-   "{AED5759B653DF6D0}Prefabs/Vegetation/Bush/b_rosa_canina_1s_collision.et"
+   "{AED5759B653DF6D0}Prefabs/Vegetation/Bush/b_rosa_canina_1s.et"
   }
+  m_bPreviewShape 0
+ }
+ {
+  coords 2771.344 64.571 1016.366
+  m_fRadius 15
+  m_prefabFilterList {
+   "{4496274873A16B3D}Prefabs/Props/Furniture/LampFluorescent/lampfluorescent_01_exterior_ruha_inside.et"
+   "{8FF50E5D4B417196}Prefabs/Props/Furniture/LampFluorescent/LampFluorescent_01_glass.et"
+   "{325D270D0A1FE2D4}Prefabs/Structures/Infrastructure/Lamps/LampStreet_E_01/LightPrefabs/LampStreet_E_01_light.et"
+  }
+  m_bByParentOnly 0
+  m_bPreviewShape 0
+ }
+ {
+  coords 2727.17 57.474 947.238
+  m_fRadius 15
+  m_prefabFilterList {
+   "{4496274873A16B3D}Prefabs/Props/Furniture/LampFluorescent/lampfluorescent_01_exterior_ruha_inside.et"
+   "{8FF50E5D4B417196}Prefabs/Props/Furniture/LampFluorescent/LampFluorescent_01_glass.et"
+   "{325D270D0A1FE2D4}Prefabs/Structures/Infrastructure/Lamps/LampStreet_E_01/LightPrefabs/LampStreet_E_01_light.et"
+  }
+  m_bByParentOnly 0
+  m_bPreviewShape 0
  }
 }

--- a/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/Systems/MISC.layer
+++ b/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/Systems/MISC.layer
@@ -43,6 +43,8 @@ TILW_PresenceTriggerEntity MeetingTrigger : "{826E6F2246328952}Prefabs/Logic/Tri
  }
  m_flagName "MeetingCompleted"
  m_stopAfterFirstChange 1
+ m_drawShapeSurface 0
+ m_drawShapeOutline 0
  m_entityNames {
   "BrownMobBoss"
   "GreyMobBoss"

--- a/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/default.layer
+++ b/worlds/TheLocalPub/PublicEnemies/PublicEnemies_Layers/default.layer
@@ -11,19 +11,17 @@ PerceptionManager PerceptionManager2 : "{028DAEAD63E056BE}Prefabs/World/Game/Per
 PS_GameModeCoop PS_GameMode_Lobby_GC1 : "{4CFD54745CD45673}Prefabs/MP/Modes/PS_GameMode_Lobby_GC.et" {
  components {
   SCR_TimeAndWeatherHandlerComponent "{5EE3229927D4D2F5}" {
-   m_iStartingHours 4
-   m_iStartingMinutes 45
+   m_iStartingHours 22
    m_bUsePredefineStartingTimeAndWeather 1
    m_aStartingWeatherAndTime {
     SCR_TimeAndWeatherState "{68AD304EAC9D6DCB}" {
      m_sWeatherPresetName "Clear"
-     m_iStartingHour 4
-     m_iStartingMinutes 45
+     m_iStartingHour 22
     }
    }
    m_bUseSpecifiedDate 1
    m_iSetDay 22
-   m_iSetMonth 7
+   m_iSetMonth 3
    m_iSetYear 1945
   }
  }


### PR DESCRIPTION
# Changelog
## Fixed:
- PK deleter now works correctly again meaning the buildings should display as intended (Since the last time it was updated, It appears it needed to be adjusted to work accordingly)
- The time of day has been changed to actually make it night time. For some reason it used to be dark, then Ruha updated and messed with it's timezones.

## Adjusted:
- Briefing to trim abit of fat
- Mission header

## Removed:
- 2x OPFOR players to slightly increase numbers on BLUFOR.