### PR TITLE
BugOut Update

### DIFF
--- a/worlds/TheLocalPub/BugOut/BugOut_Layers/BLUFOR/BLUFOR_BRIEF.layer
+++ b/worlds/TheLocalPub/BugOut/BugOut_Layers/BLUFOR/BLUFOR_BRIEF.layer
@@ -72,9 +72,10 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "We are to conduct a <b>FIGHTING WITHDRAWAL</b> to our extraction area in the north-east in order to rally with our vehicles and leave the AO."\
   ""\
   "<h2>MISSION DESCRIPTION</h2>  "\
-  "Our platoon harbour has been compromised following a deliberate Argentine assault. The enemy's objective is to overrun the harbour, destroy the platoon, and prevent our withdrawal."\
+  "Our platoon harbour has been compromised following contact with an Argentine patrol. We have repelled the initial attack, but it is likely only a short matter of time before a larger enemy force reacts and begins pursuing us."\
+  "Immediately break contact and bug out!"\
   ""\
-  "Remaining within the harbour will only allow the enemy to build momentum and surround our position. Instead, we are to break out of the harbour, fight through enemy blocking positions, and withdraw to our waiting Land Rovers at the designated extraction point."\
+  "Remaining within the harbour will only allow the enemy to build momentum and surround our position. Instead, we are to break out of the harbour, fight through any enemies, and withdraw to our waiting Land Rovers at the designated extraction point."\
   ""\
   "Maintain unit cohesion, avoid becoming decisively engaged, and ensure as much of the platoon as possible reaches the extraction area. Once enough surviving personnel have reached the rally we'll withdraw."
   m_aVisibleForFactions {
@@ -95,7 +96,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   ""\
   "1 Platoon, A Company, 1st Battalion, Welsh Guards, is currently taking part in a field exercise at Longmoor Training Area. The platoon has established a temporary harbour area while rehearsing tactical movement, harbour drills, and withdrawal procedures ahead of deployment."\
   ""\
-  "During the early hours of the morning, Argentine reconnaissance elements unexpectedly located the harbour and launched a deliberate assault in an attempt to overrun the position before the platoon could react. With the harbour compromised, the platoon has been ordered to break contact, fight its way back to the extraction point, and withdraw from the area before being cut off."
+  "During the early hours of the morning, Argentine reconnaissance elements unexpectedly located the harbou. British troops killed the small force, but with the harbour compromised, the platoon has been ordered to break contact, fight its way back to the extraction point, and withdraw from the area before being cut off."
   m_aVisibleForFactions {
    "UK"
   }

--- a/worlds/TheLocalPub/BugOut/BugOut_Layers/OPFOR/AI.layer
+++ b/worlds/TheLocalPub/BugOut/BugOut_Layers/OPFOR/AI.layer
@@ -1,17 +1,23 @@
 $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpawner.et" {
  OPFOR_RIFLE2 {
-  coords 766.426 97.595 385.824
-  angles 0 -160.391 0
+  coords 535.432 91.938 327.936
+  angles 0 144.63 0
   m_prefab "{D8344706E15AF07A}Prefabs/Groups/OPFOR/GC_ARG/1980_Regulars/Group_ARG_RifleSquad.et"
+  m_spawnTimings {
+   180
+  }
   m_waypointNames {
    "WP_M2"
    "WP_ATK1"
   }
  }
  OPFOR_RIFLE3 {
-  coords 490.973 83.126 153.511
+  coords 480.656 84.989 42.043
   angles 0 70.704 0
   m_prefab "{D8344706E15AF07A}Prefabs/Groups/OPFOR/GC_ARG/1980_Regulars/Group_ARG_RifleSquad.et"
+  m_spawnTimings {
+   180
+  }
   m_waypointNames {
    "WP_M3"
    "WP_ATK1"

--- a/worlds/TheLocalPub/BugOut/BugOut_Layers/OPFOR/AI.layer
+++ b/worlds/TheLocalPub/BugOut/BugOut_Layers/OPFOR/AI.layer
@@ -7,8 +7,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    180
   }
   m_waypointNames {
-   "WP_M2"
-   "WP_ATK1"
+   "WP_FLW2"
   }
  }
  OPFOR_RIFLE3 {
@@ -19,8 +18,7 @@ $grp TILW_PrefabSpawnerEntity : "{7F10372CF1CA1175}Prefabs/Utils/TILW_PrefabSpaw
    180
   }
   m_waypointNames {
-   "WP_M3"
-   "WP_ATK1"
+   "WP_FLW1"
   }
  }
  OPFOR_RIFLE4 {

--- a/worlds/TheLocalPub/BugOut/BugOut_Layers/OPFOR/WP.layer
+++ b/worlds/TheLocalPub/BugOut/BugOut_Layers/OPFOR/WP.layer
@@ -19,6 +19,9 @@ $grp SCR_EntityWaypoint : "{1B0E3436C30FA211}Prefabs/AI/Waypoints/AIWaypoint_Att
     m_eCause COMBAT
    }
   }
+  m_EntityWaypointParameters SCR_AIEntityWaypointParameters "{6A12ADADCB198EE4}" {
+   m_sEntityName "PLT1HQ"
+  }
  }
  WP_ATK2 {
   coords 2022.714 129.657 836.521
@@ -44,7 +47,8 @@ $grp SCR_EntityWaypoint : "{1B0E3436C30FA211}Prefabs/AI/Waypoints/AIWaypoint_Att
 }
 $grp SCR_AIWaypoint : "{750A8D1695BD6998}Prefabs/AI/Waypoints/AIWaypoint_Move.et" {
  WP_M2 {
-  coords 764.982 92.331 386.175
+  coords 534.316 92.24 326.954
+  angles 0 -54.979 0
   m_aSettings {
    SCR_AICharacterMovementSpeedSetting "{6A072A1E050E9A60}" {
     m_eCause DANGER_MEDIUM
@@ -61,7 +65,7 @@ $grp SCR_AIWaypoint : "{750A8D1695BD6998}Prefabs/AI/Waypoints/AIWaypoint_Move.et
   }
  }
  WP_M3 {
-  coords 490.76 83.127 153.376
+  coords 480.443 84.987 41.908
   m_aSettings {
    SCR_AICharacterMovementSpeedSetting "{6A072A1E050E9A60}" {
     m_eCause DANGER_MEDIUM

--- a/worlds/TheLocalPub/BugOut/BugOut_Layers/OPFOR/WP.layer
+++ b/worlds/TheLocalPub/BugOut/BugOut_Layers/OPFOR/WP.layer
@@ -1,86 +1,25 @@
-$grp SCR_EntityWaypoint : "{1B0E3436C30FA211}Prefabs/AI/Waypoints/AIWaypoint_Attack.et" {
- WP_ATK1 {
-  coords 666.244 85.618 231.443
-  m_aSettings {
-   SCR_AICharacterMovementSpeedSetting "{6A0F0286597A199D}" {
-    m_eCause COMBAT
-    m_eSpeed RUN
-   }
-   SCR_AICharacterStanceSetting "{6A0F0286551E65A3}" {
-    m_eCause COMBAT
-    m_eStance STAND
-   }
-   SCR_AIGroupFormationSetting "{6A0F028642252F56}" {
-    m_eFormation Line
-   }
-   SCR_AIGroupCombatModeSetting "{6A0F0286BEDF720F}" {
-   }
-   SCR_AICharacterLightInteractionSetting "{6A0F0283458F7793}" {
-    m_eCause COMBAT
-   }
+SCR_EntityWaypoint WP_ATK2 : "{1B0E3436C30FA211}Prefabs/AI/Waypoints/AIWaypoint_Attack.et" {
+ coords 2022.714 129.657 836.521
+ m_aSettings {
+  SCR_AICharacterMovementSpeedSetting "{6A0F0286597A199D}" {
+   m_eCause COMBAT
+   m_eSpeed RUN
   }
-  m_EntityWaypointParameters SCR_AIEntityWaypointParameters "{6A12ADADCB198EE4}" {
-   m_sEntityName "PLT1HQ"
+  SCR_AICharacterStanceSetting "{6A0F0286551E65A3}" {
+   m_eCause COMBAT
+   m_eStance STAND
   }
- }
- WP_ATK2 {
-  coords 2022.714 129.657 836.521
-  m_aSettings {
-   SCR_AICharacterMovementSpeedSetting "{6A0F0286597A199D}" {
-    m_eCause COMBAT
-    m_eSpeed RUN
-   }
-   SCR_AICharacterStanceSetting "{6A0F0286551E65A3}" {
-    m_eCause COMBAT
-    m_eStance STAND
-   }
-   SCR_AIGroupFormationSetting "{6A0F028642252F56}" {
-    m_eFormation Line
-   }
-   SCR_AIGroupCombatModeSetting "{6A0F0286BEDF720F}" {
-   }
-   SCR_AICharacterLightInteractionSetting "{6A0F0283458F7793}" {
-    m_eCause COMBAT
-   }
+  SCR_AIGroupFormationSetting "{6A0F028642252F56}" {
+   m_eFormation Line
+  }
+  SCR_AIGroupCombatModeSetting "{6A0F0286BEDF720F}" {
+  }
+  SCR_AICharacterLightInteractionSetting "{6A0F0283458F7793}" {
+   m_eCause COMBAT
   }
  }
 }
 $grp SCR_AIWaypoint : "{750A8D1695BD6998}Prefabs/AI/Waypoints/AIWaypoint_Move.et" {
- WP_M2 {
-  coords 534.316 92.24 326.954
-  angles 0 -54.979 0
-  m_aSettings {
-   SCR_AICharacterMovementSpeedSetting "{6A072A1E050E9A60}" {
-    m_eCause DANGER_MEDIUM
-    m_eSpeed RUN
-   }
-   SCR_AIGroupFormationSetting "{6A072A1E709E2F09}" {
-    m_eFormation Line
-   }
-   SCR_AIGroupCombatModeSetting "{6A072A1E68A6E829}" {
-   }
-   SCR_AICharacterLightInteractionSetting "{6A0F0284903DF0DC}" {
-    m_eCause COMBAT
-   }
-  }
- }
- WP_M3 {
-  coords 480.443 84.987 41.908
-  m_aSettings {
-   SCR_AICharacterMovementSpeedSetting "{6A072A1E050E9A60}" {
-    m_eCause DANGER_MEDIUM
-    m_eSpeed RUN
-   }
-   SCR_AIGroupFormationSetting "{6A072A1E709E2F09}" {
-    m_eFormation Line
-   }
-   SCR_AIGroupCombatModeSetting "{6A072A1E68A6E829}" {
-   }
-   SCR_AICharacterLightInteractionSetting "{6A0F0284903DF0DC}" {
-    m_eCause COMBAT
-   }
-  }
- }
  WP_M4 {
   coords 2006.4 132.612 136.073
   m_aSettings {
@@ -113,6 +52,48 @@ $grp SCR_AIWaypoint : "{750A8D1695BD6998}Prefabs/AI/Waypoints/AIWaypoint_Move.et
    SCR_AICharacterLightInteractionSetting "{6A0F0284903DF0DC}" {
     m_eCause COMBAT
    }
+  }
+ }
+}
+$grp SCR_EntityWaypoint : "{A0509D3C4DD4475E}Prefabs/AI/Waypoints/AIWaypoint_Follow.et" {
+ WP_FLW1 {
+  coords 481.057 85.032 41.365
+  m_aSettings {
+   SCR_AIGroupFormationSetting "{6A12C517820520E4}" {
+    m_eFormation Line
+   }
+   SCR_AIGroupCombatModeSetting "{6A12C51787AAE47B}" {
+   }
+   SCR_AICharacterLightInteractionSetting "{6A12C517FB64B5A3}" {
+    m_eCause COMBAT
+   }
+   SCR_AICharacterMovementSpeedSetting "{6A12C517FFC1A977}" {
+    m_eCause COMBAT
+    m_eSpeed RUN
+   }
+  }
+  m_EntityWaypointParameters SCR_AIEntityWaypointParameters "{60D91038885C820A}" {
+   m_sEntityName "PLT1HQ"
+  }
+ }
+ WP_FLW2 {
+  coords 534.69 91.937 326.113
+  m_aSettings {
+   SCR_AIGroupFormationSetting "{6A12C517820520E4}" {
+    m_eFormation Line
+   }
+   SCR_AIGroupCombatModeSetting "{6A12C51787AAE47B}" {
+   }
+   SCR_AICharacterLightInteractionSetting "{6A12C517FB64B5A3}" {
+    m_eCause COMBAT
+   }
+   SCR_AICharacterMovementSpeedSetting "{6A12C517FFC1A977}" {
+    m_eCause COMBAT
+    m_eSpeed RUN
+   }
+  }
+  m_EntityWaypointParameters SCR_AIEntityWaypointParameters "{60D91038885C820A}" {
+   m_sEntityName "PLT1_SEC1"
   }
  }
 }

--- a/worlds/TheLocalPub/BugOut/BugOut_Layers/SYSTEMS/ALL_BRIEFS.layer
+++ b/worlds/TheLocalPub/BugOut/BugOut_Layers/SYSTEMS/ALL_BRIEFS.layer
@@ -21,12 +21,12 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
  SUMMARY {
   coords 2226.888 0 9533.049
   m_sTitle "Summary"
-  m_sTextData "British forces on pre-deployment training must break out from their compromised platoon harbour after coming under attack. Repel the initial assault before fighting your way to the extraction area while pursued by Argentinian troops."\
+  m_sTextData "British forces conducting pre-deployment training must break out from their compromised platoon harbour after an Argentine patrol unexpectedly discovers their position."\
   ""\
-  "Will the platoon break contact and escape, or be overrun before reaching extraction?"\
+  "Having repelled the initial contact, can the platoon move fast enough to outrun the pursuing enemy and fight through the forces closing in on their callsign?"\
   ""\
   "<h2>Summary Notes</h2>"\
-  "• Fighting begins almost immediately after spawning. <b>STAND TO!</b>"
+  "• Delaying manoeuvres at the start of the mission will be detrimental to the British force. <b>Stand to and bug out!</b>"
   m_bEmptyFactionVisibility 1
   m_iOrder 0
  }


### PR DESCRIPTION
# Changelog

## Adjusted:
- Concept has changed slightly for the initial spawn. Instead of the UK team now having to immediately stand-to and be ready instantly to repel an assault. The lore has changed to that a patrol came across the UK harbour area, was engaged, destroyed, but now the harbour is compromised.
UK team now has 3mins until the units spawn. They were moved slightly further to increase running time just a tiny bit.
This should give roughly 3.30min for the UK team to start moving off before the enemy starts to engage.
These AI have been set to a follow WP now instead of an attack WP on the harbour area. They will now follow the UK team regardless of where they go.