### PR TITLE
Cimic house update

### DIFF
--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/BLUFOR/Turrets.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/BLUFOR/Turrets.layer
@@ -132,6 +132,9 @@ Vehicle _Series_LWB_Transport1 : "{701ADC27F9D842DF}Prefabs/Vehicles/Wheeled/LR_
    m_lockPilot 1
    m_lockTurret 1
    m_lockCargo 1
+   m_factionLock {
+    "FIA"
+   }
   }
   SCR_UniversalInventoryStorageComponent "{648B4DF41C28F11F}" {
    MultiSlots {
@@ -154,6 +157,9 @@ Vehicle _Series_SWB_Transport1 : "{EDEAE951AFF2A836}Prefabs/Vehicles/Wheeled/LR_
    m_lockPilot 1
    m_lockTurret 1
    m_lockCargo 1
+   m_factionLock {
+    "FIA"
+   }
   }
   SCR_UniversalInventoryStorageComponent "{648B4DF41C28F11F}" {
    MultiSlots {

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/OPFOR/WP.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/OPFOR/WP.layer
@@ -186,6 +186,7 @@ SCR_EntityWaypoint Attack1 : "{1B0E3436C30FA211}Prefabs/AI/Waypoints/AIWaypoint_
  coords 4348.01 17.844 3902.4
  angles 0 41.494 0
  CompletionRadius 20
+ m_fPriorityLevel 100
  m_aSettings {
   SCR_AIGroupCombatModeSetting "{69E8F113F2DA06AA}" {
   }

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllBriefs.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllBriefs.layer
@@ -32,7 +32,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   "• Overrun the British garrison by eliminating at least 85% (26/30) of British forces and occupy the compound."\
   ""\
   "<h2>Mission Notes</h2>"\
-  "• E-tool usage is strictly forbidden."\
+  "• E-tool usage is strictly forbidden and so is the use of any vehicle. These will break AI pathfinding in the compound. Leave everything as it is."\
   "• Iraqi forces only to be slotted if missions is <b>FULL</b> or if blufor accept the challenge."\
   "• JIP TP."\
   "• UK AO limit."\

--- a/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllBriefs.layer
+++ b/worlds/TheLocalPub/CimicHouse/CimicHouse_Layers/SYSTEMS/AllBriefs.layer
@@ -45,17 +45,9 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
  CL {
   coords 7070.548 152.503 742.933
   m_sTitle "Changelog"
-  m_sTextData "<h2>Added:</h2>"\
-  "• More buildings around the outside of the compound and their respective markers."\
-  "• Further low/small cover to the area outside the compound to make the AI not a total turkey shoot at times."\
-  "• Further fortifications to the compound, including a ladder to the garage roof with fighting positions."\
-  "• UK AO limit to brief."\
-  "• MMG Markers"\
-  ""\
-  "<h2>Changed:</h2>"\
-  "• AI settings - They should now be more aggressive, faster to the compound, and also better at engaging from a distance."\
-  "• AI numbers - Increased by 10 units a wave."\
-  "• AI placement - Moved some groups to different areas to try spread out their direction of travel."
+  m_sTextData "<h2>Changed:</h2>"\
+  "• Adjust AI waypoint so they do less shooting and abit more moving now hopefully. Still trying to find the sweet spot."\
+  "• Vehicles at spawn should hopefully not be accessible now. They were locked before, but I'm trying again."
   m_bEmptyFactionVisibility 1
   m_bShowForAnyFaction 1
   m_iOrder 11


### PR DESCRIPTION
# Changelog

## Changed
- AI WP priority. While they were better this play through, they  done abit to much shooting from a distance instead of moving forward. I've upped the waypoint priority abit to see if it makes much difference.
- Hopefully locked the vehicles at spawn. I did lock them previously but they were still enterable? I've tried adding a faction key now and it appears to work? We'll see.... I just dont want people moving the vehicle in the tiny compound and fucking up AI path finding.